### PR TITLE
refactor: mount-don't-convert disk images via qemu-nbd (DISCIPLINE v4)

### DIFF
--- a/.claude/agents/dfir-correlator.md
+++ b/.claude/agents/dfir-correlator.md
@@ -5,7 +5,7 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 model: opus
 ---
 
-<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v3_loaded` in the result field.</mandatory>
+<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v4_loaded` in the result field.</mandatory>
 
 <role>Correlation phase: weave structured findings into a cross-artifact narrative. Read structured findings only — never raw tool output.</role>
 

--- a/.claude/agents/dfir-investigator.md
+++ b/.claude/agents/dfir-investigator.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Write, Edit, Glob, Grep
 model: sonnet
 ---
 
-<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v3_loaded` in the result field.</mandatory>
+<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v4_loaded` in the result field.</mandatory>
 
 <role>Investigation phase: take one lead, confirm / refute / escalate / block it. No surveying, no reporting.</role>
 

--- a/.claude/agents/dfir-qa.md
+++ b/.claude/agents/dfir-qa.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Write, Edit, Glob, Grep
 model: opus
 ---
 
-<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v3_loaded` in the result field.</mandatory>
+<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v4_loaded` in the result field.</mandatory>
 
 <role>QA phase: the last technical gate before sign-off. Reconcile prior-phase output against authoritative artifacts and across documents. Edit in place when the fix is fact-level; re-dispatch a phase when its output is wrong or missing. Self-loop to convergence.</role>
 
@@ -63,7 +63,9 @@ model: opus
 | Whole domain or whole evidence item missing analysis | redispatch Phase 1 or 2 | §I |
 | Correlation matrix references a finding you just edited (stale cell) | redispatch Phase 4 | §B |
 | `final.md` / `stakeholder-summary.md` cite numbers that do not match findings | redispatch Phase 5 | §B |
-| Manifest classifies `EV02` as `pcap` but the file is `.E01` | redispatch Phase 1, target `EV02` | §P-diskimage, §I |
+| Manifest classifies `EV02` as `pcap` but the file is a disk image | redispatch Phase 1, target `EV02` | §P-diskimage, §I |
+| `disk-mount` row missing parent `blob` row OR either has empty sha256 | redispatch Phase 1 (re-run `diskimage-mount.sh`) | §P-diskimage |
+| `disk-mount` sentinel says `mounted=true` but `/dev/nbd<N>` is not attached | run `diskimage-unmount.sh <EV>` then redispatch Phase 1 to re-mount | §P-diskimage |
 | Surveyor never ran on `EV03 × yara` even though `EV03` is a disk image | redispatch Phase 2, target `EV03 × yara` | §I |
 | `MITRE:` line malformed (`t1059`, `T123`, missing dot) | edit-in-place (smallest fix) | §K |
 | `MITRE:` ID unknown to the TSV | log to `qa-review.md` "Discipline issues"; do NOT silently delete; analyst extends TSV or orchestrator dispatches focused Phase 3 | §K |
@@ -100,7 +102,7 @@ The QA agent's `tools:` field intentionally omits `Agent`. The directive file ke
 
 <protocol>
 
-<step n="1">Discipline self-attest. First action: append an audit-log entry via `audit.sh` with `discipline_v3_loaded` in the result field, naming this invocation `dfir-qa phase-6 start`.</step>
+<step n="1">Discipline self-attest. First action: append an audit-log entry via `audit.sh` with `discipline_v4_loaded` in the result field, naming this invocation `dfir-qa phase-6 start`.</step>
 
 <step n="2">Intake completeness gate per <rule ref="DISCIPLINE §J"/>.
 - Run `bash .claude/skills/dfir-bootstrap/intake-check.sh`.
@@ -170,7 +172,7 @@ When your edit changes a value cited in `correlation.md`, queue a Phase 4 re-dis
 - Locate every entity (IP, host, hash, actor) named in one document and absent from another that should reference it. Add the cross-reference when load-bearing.</step>
 
 <step n="11">Discipline ledger sweep.
-- `grep -c discipline_v3_loaded ./analysis/forensic_audit.log` — ≥ once per agent invocation. When a phase agent ran without the marker, record an `INTEGRITY-VIOLATION` audit row naming the missing phase. Do NOT fabricate the marker.
+- `grep -c discipline_v4_loaded ./analysis/forensic_audit.log` — ≥ once per agent invocation. When a phase agent ran without the marker, record an `INTEGRITY-VIOLATION` audit row naming the missing phase. Do NOT fabricate the marker.
 - Scan the audit log for direct-write attempts (lines that look ISO-8601 / `T...Z` rather than `YYYY-MM-DD HH:MM:SS UTC`). When present, surface as integrity violations in `qa-review.md`.
 - Count duplicate audit rows (same timestamp + same action). The `audit-exports.sh` hook double-fires occasionally; duplicates are noise, not violations, but note the count.
 - Count `[qa-redispatch]` rows in the audit log. These are orchestrator-emitted rows logging that it picked up a row from your previous-pass directive file and dispatched the named phase. The count equals the number of rows across all prior `.qa-redispatch-pending` snapshots (use `qa-history.md` for prior counts). A mismatch means the orchestrator dropped a re-dispatch — surface as an integrity violation.</step>
@@ -265,6 +267,8 @@ QA loops on itself until the case is internally consistent. Loop terminates when
 4. Verdict is `PASS` or `PASS-WITH-CHANGES`.
 
 Compute the `qa-review.md` sha as the LAST action of every pass, record it in `qa-review.md` § "Convergence", and append the row to `./analysis/qa-history.md`. The orchestrator detects a pathological loop via the ledger: when your sha matches the previous pass's sha BUT the directive file is non-empty, halt and surface to the user.
+
+**Disk-image dismount gate (case close).** Once convergence holds AND verdict is PASS / PASS-WITH-CHANGES, run `bash .claude/skills/dfir-bootstrap/diskimage-unmount-all.sh` BEFORE emitting the final sign-off. The helper walks every `./working/mounts/.<EV>.mount.json` sentinel, calls `diskimage-unmount.sh <EV>` per row, and audits each `umount` / `qemu-nbd --disconnect` / `fusermount -u`. Refuse sign-off if the helper exits nonzero — orphan `/dev/nbd<N>` attachments are a chain-of-custody concern. Sentinels are NOT deleted (chain-of-custody record).
 </convergence>
 
 <rules-binding>

--- a/.claude/agents/dfir-reporter.md
+++ b/.claude/agents/dfir-reporter.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Write, Edit, Glob, Grep
 model: haiku
 ---
 
-<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v3_loaded` in the result field.</mandatory>
+<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v4_loaded` in the result field.</mandatory>
 
 <role>Report phase: consume structured analysis artifacts and produce the human-readable case report. No forensic tool execution.</role>
 

--- a/.claude/agents/dfir-surveyor.md
+++ b/.claude/agents/dfir-surveyor.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Write, Edit, Glob, Grep
 model: sonnet
 ---
 
-<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v3_loaded` in the result field.</mandatory>
+<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v4_loaded` in the result field.</mandatory>
 
 <role>Survey phase: one evidence item × one domain. Run the cheapest, highest-signal passes and emit leads.</role>
 
@@ -15,6 +15,14 @@ model: sonnet
 - Case question if known; otherwise `unguided`
 - CWD: `./cases/<CASE_ID>/`. Project skills live at `${CLAUDE_PROJECT_DIR}/.claude/skills/...`.
 </inputs>
+
+<disk-image-reads>
+When `EVIDENCE_ID` has a `disk-mount` row in `./analysis/manifest.md` (key `<EV>-MOUNT`), read off the read-only mount surface produced by `diskimage-mount.sh` per <rule ref="DISCIPLINE §P-diskimage"/>:
+- **Raw-stream tools** (`mmls`, `fls`, `fsstat`, `icat`, `tsk_recover`, `log2timeline.py`, `bulk_extractor`) → `/dev/nbd<N>` (read from the manifest row's `notes` column, key `nbd=`).
+- **File-tree tools** (`EvtxECmd`, `RECmd`, `MFTECmd`, `AmcacheParser`, `yara` against a directory) → `./working/mounts/<EV>/p<M>/` (mount points listed in the row's `notes` column, key `mount-points=`).
+
+NEVER invoke `ewfacquire` or otherwise convert the source. The mount IS the surface. Detachment is owned by `diskimage-unmount.sh` / `diskimage-unmount-all.sh` (sequential cleanup + QA case-close).
+</disk-image-reads>
 
 <domain-map>
 Canonical `DOMAIN` names match the subdirs `case-init.sh` creates. Use them verbatim for output paths; load the skill by path.
@@ -53,7 +61,7 @@ On non-zero exit, STOP and report the mismatch. Never silently re-hash. Applies 
 <step n="6">Write tool output (survey CSVs, parsed JSON) under the domain subdir.</step>
 
 <step n="7">Instantiate the template at `./analysis/<DOMAIN>/survey-<EVIDENCE_ID>.md`. The six required sections in order: `# Header`, `## Tools run`, `## Findings of interest`, `## Lead summary table`, `## Negative results`, `## Open questions`. Populate every field; never leave placeholders (`<sha256>`, `<EV_ID>`, etc.) in the file.
-- **Header**: case ID, evidence ID, evidence sha256 (copy from `./analysis/manifest.md`), domain, surveyor agent version (`dfir-surveyor / discipline_v3_loaded`), UTC timestamp.
+- **Header**: case ID, evidence ID, evidence sha256 (copy from `./analysis/manifest.md`), domain, surveyor agent version (`dfir-surveyor / discipline_v4_loaded`), UTC timestamp.
 - **Tools run**: every cheap-signal invocation as `<tool> -> <invocation> -> exit <code> -> <output path>`.
 - **Findings of interest**: 3–5 single-line bullets, each with a line-anchored pointer (`<file>#L<n>` or `<file>#L<n>-L<m>`) and a stub lead ID at the end.
 - **Lead summary table**: columns `lead_id | priority | hypothesis | next-step query | est-cost`. At least one data row, or an explicit `(no leads)` placeholder.

--- a/.claude/agents/dfir-triage.md
+++ b/.claude/agents/dfir-triage.md
@@ -1,13 +1,13 @@
 ---
 name: dfir-triage
-description: Phase 1 — case bootstrap. Run preflight, scaffold the case, inventory and classify every piece of evidence under the case directory, and emit the evidence manifest. Use as the FIRST agent for any new case. Does not analyze artifacts. Triggers — case start, `/case <ID>`, fresh evidence directory. Skip for deep analysis (use `dfir-surveyor` / `dfir-investigator`) or report writing (use `dfir-reporter`).
+description: Phase 1 — case bootstrap. Run preflight, scaffold the case, mount every disk image read-only via qemu-nbd, inventory and classify every piece of evidence under the case directory, and emit the evidence manifest. Use as the FIRST agent for any new case. Does not analyze artifacts. Triggers — case start, `/case <ID>`, fresh evidence directory. Skip for deep analysis (use `dfir-surveyor` / `dfir-investigator`) or report writing (use `dfir-reporter`).
 tools: Bash, Read, Write, Edit, Glob, Grep
 model: haiku
 ---
 
-<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v3_loaded` in the result field.</mandatory>
+<mandatory>Read `.claude/skills/dfir-discipline/DISCIPLINE.md` before acting. Your first audit-log entry of this invocation MUST contain `discipline_v4_loaded` in the result field.</mandatory>
 
-<role>Triage phase: scaffold the case workspace and emit a clean, classified evidence manifest. No artifact analysis.</role>
+<role>Triage phase: scaffold the case workspace, mount every disk image read-only, and emit a clean classified manifest. No artifact analysis.</role>
 
 <inputs>
 - `$CASE_ID` (from prompt)
@@ -17,28 +17,42 @@ model: haiku
 
 <protocol>
 
-<step n="1">Run preflight to disk (output is ~300 lines — never tee to stdout):
+<step n="1" name="preflight">Run preflight to disk (output is ~300 lines — never tee to stdout):
 ```bash
 bash .claude/skills/dfir-bootstrap/preflight.sh > ./analysis/preflight.md 2>&1
 grep '^SKILL_STATUS:' ./analysis/preflight.md
 ```
-The 7 `SKILL_STATUS:` lines are authoritative. `GREEN`/`YELLOW` = usable; `RED` = blocked. The `## dpkg packages` section is informational only — tools installed from upstream source (e.g. Zeek from OpenSUSE OBS) appear `MISSING` in dpkg while the binary is on PATH and the domain is `GREEN`. Do NOT cite dpkg rows as readiness signal.</step>
+The `SKILL_STATUS:` lines (including `disk-image-mount`) are authoritative. `GREEN`/`YELLOW` = usable; `RED` = blocked. The `## dpkg packages` section is informational only.</step>
 
-<step n="2">Disk-image conversion gate. Inspect every file under `./evidence/`. If any disk image is not in `.E01` form, convert per <rule ref="DISCIPLINE §P-diskimage"/> before invoking `case-init.sh`. The converted `.E01` is the manifest entry; the original goes to `./evidence/originals/` with its own sha256 row.</step>
-
-<step n="3">Pre-extraction disk-space planner:
+<step n="2" name="extraction-plan">Pre-extraction disk-space planner:
 ```bash
 bash .claude/skills/dfir-bootstrap/extraction-plan.sh
 ```
-Reads `./evidence/` depth-unbounded, sums estimated decompressed size for every archive, compares against free disk at `./working/` (20% headroom; override with `HEADROOM_PCT`), writes `./analysis/extraction-plan.md`. `./working/` is layer-2 evidence-grade staging tracked by `manifest.md`, not `./exports/` (layer-4 derived). Modes:
-- `bulk` — total + headroom fits free space. Set `BULK_EXTRACT=1` for step 4.
-- `sequential` — total exceeds free but every individual archive fits. Set `BULK_EXTRACT=0`; stage only the smallest archive first; return `sequential mode active; first stage staged`. The orchestrator drives subsequent stages per `ORCHESTRATE.md` § Sequential extraction protocol.
-- `blocked` (planner exit 1) — at least one archive's size + headroom exceeds free. Planner has appended `L-EXTRACT-DISK-NN` to `./analysis/leads.md`. Return `BLOCKED: L-EXTRACT-DISK-NN` and STOP.</step>
+Reads `./evidence/` depth-unbounded, sums estimated decompressed size for every archive, compares against free disk at `./working/` (20% headroom; override with `HEADROOM_PCT`), writes `./analysis/extraction-plan.md`. Modes:
+- `bulk` — total + headroom fits free space. Set `BULK_EXTRACT=1` for step 3.
+- `sequential` — total exceeds free but every individual archive fits. Set `BULK_EXTRACT=0`; stage only the smallest archive first; orchestrator drives subsequent stages per `ORCHESTRATE.md` § Sequential extraction protocol.
+- `blocked` (planner exit 1) — at least one archive's size + headroom exceeds free. Planner appended `L-EXTRACT-DISK-NN` to `./analysis/leads.md`. Return `BLOCKED: L-EXTRACT-DISK-NN` and STOP.</step>
 
-<step n="4">`BULK_EXTRACT=<0|1> bash .claude/skills/dfir-bootstrap/case-init.sh "$CASE_ID"` — creates `./working/`, walks `./evidence/`, sha256-hashes every file, expands zip / tar / tar.gz / 7z bundles under `./working/<basename>/` (when `BULK_EXTRACT=1`), seeds `./analysis/manifest.md` with one row per top-level item AND one row per bundle member. With `BULK_EXTRACT=0` it scaffolds + hashes but skips bundle expansion. Do NOT re-hash bundle members — verify in step 6.</step>
+<step n="3" name="extract">`BULK_EXTRACT=<0|1> bash .claude/skills/dfir-bootstrap/case-init.sh "$CASE_ID"` — creates `./working/` + `./working/mounts/`, walks `./evidence/`, sha256-hashes every file, expands archives under `./working/<basename>/` (when `BULK_EXTRACT=1`), seeds `./analysis/manifest.md` with one row per top-level item AND one row per bundle member. Do NOT re-hash bundle members — verify in step 7.</step>
 
-<step n="5">Classify each evidence item:
-- **disk** — `.E01`, `.dd`, `.raw` matching partition layout (verify with `ewfinfo` or `mmls`)
+<step n="4" name="diskimage-gate">
+  <reasoning>Detect each disk image's format → pick adapter chain → estimate logical size → verify free disk for mount overhead → mount via qemu-nbd (and ewfmount for E01) → hash original + `/dev/nbd<N>` byte stream → manifest both rows → audit every command. NO E01 conversion. Disk images stay in their native format under `./evidence/` (or under `./working/<bundle>/...` when nested inside an extracted archive). Surveyors and downstream tools operate off the read-only mount.</reasoning>
+
+  <substep n="4.1">Plan: `bash .claude/skills/dfir-bootstrap/diskimage-plan.sh`. Walks both `./evidence/` AND `./working/` depth-unbounded for disk images (E01, raw/dd, vmdk, vhd, vhdx, qcow2). On `mode=blocked`: surface the `L-MOUNT-DISK-NN` row and STOP.</substep>
+
+  <substep n="4.2">For each disk image listed in `./analysis/diskimage-plan.md`, mount via the canonical helper (which records every command per <rule ref="DISCIPLINE §P-diskimage"/>):
+```bash
+bash .claude/skills/dfir-bootstrap/diskimage-mount.sh <relpath> <next-EV-id>
+```
+Helper detects format, runs `modprobe nbd` if needed, runs `ewfmount` for E01, attaches `qemu-nbd --read-only --cache=none --format=<fmt> --connect=/dev/nbd<N>`, runs `mmls`, mounts each partition under `./working/mounts/<EV>/p<M>/`, hashes the source file AND `/dev/nbd<N>` byte stream, writes a sentinel at `./working/mounts/.<EV>.mount.json`, and traps detach on every failure path.</substep>
+
+  <substep n="4.3">Re-run `bash .claude/skills/dfir-bootstrap/case-init.sh "$CASE_ID"`. The sentinel sweep recognizes each `*.mount.json` and appends a `disk-mount` manifest row (`<EV>-MOUNT`, `parent=<EV>`, `notes=adapter=<chain>; mount-points=<list>; nbd-byte-sha256=<sha>`). Idempotent — rows already present are skipped.</substep>
+
+  <substep n="4.4">DO NOT run `ewfacquire` against any source. Conversion to E01 is retired (v4). Surveyors read from `./working/mounts/<EV>/p<M>/` (file-tree access) or `/dev/nbd<N>` (raw-stream access for `mmls`, `fls`, `log2timeline.py`, `bulk_extractor`).</substep>
+</step>
+
+<step n="5" name="classify">Classify each evidence item:
+- **disk** — `.E01`, `.dd`, `.raw`, `.img`, `.vmdk`, `.vhd`, `.vhdx`, `.qcow2` (verified by step 4 — `disk-mount` row present in `manifest.md`)
 - **memory** — `.mem`, `.raw`, `.vmem`, `.dmp` (`file` reports no MBR/GPT; size matches RAM)
 - **logs** — `.evtx`, `.log`, `.json`, archive of exported logs (non-network)
 - **triage-bundle** — KAPE / CyLR / Velociraptor (look for `C/` or `Uploads/` structure)
@@ -46,39 +60,42 @@ Reads `./evidence/` depth-unbounded, sums estimated decompressed size for every 
 - **netlog** — Zeek log dir (`conn.log`/`dns.log`/`http.log` with `#fields`), Suricata `eve.json`, NetFlow `*.nfcapd` / `nfdump` exports
 - **other** — mail stores, mobile images, container snapshots (note; do not deep-classify)</step>
 
-<step n="6">Verify the manifest case-init produced. For each `bundle:*` row, confirm `find ./working/<basename>/ -type f | wc -l` matches the count of `bundle-member` rows whose `parent` field is the bundle's `evidence_id`. If counts differ, fix `manifest.md` (do NOT modify the bundle on disk) and emit an `audit.sh` `manifest-mismatch` row. For each `bundle-member` row, populate the `notes` field with a `type` classification (e.g. `pcap`, `logs`) so surveyors fan into the right domain. Emit `audit.sh` `manifest-verified: N items, M members`.</step>
+<step n="6" name="verify-manifest">Verify the manifest. For each `bundle:*` row, confirm `find ./working/<basename>/ -type f | wc -l` matches the count of `bundle-member` rows whose `parent` field is the bundle's `evidence_id`. For each `disk-mount` row, confirm a parent `blob` row exists with matching `evidence_id` AND non-empty sha256. Run `bash .claude/skills/dfir-bootstrap/manifest-check.sh` — exit 0 = clean; nonzero = violations are now BLOCKED leads (`L-MOUNT-LEDGER-NN`, `L-MANIFEST-BESPOKE-NN`, etc.). Emit `audit.sh manifest-verified: N items, M members, K mounts`.</step>
 
-<step n="7">If any non-bundle evidence remains unhashed (case-init missed it), hash it and append `EVNN` rows to `./analysis/manifest.md` directly.</step>
+<step n="7" name="hash-leftover">If any non-bundle, non-disk-mount evidence remains unhashed (case-init missed it), hash it and append `EVNN` rows to `./analysis/manifest.md` directly.</step>
 
-<step n="8">Initialize `./analysis/leads.md` if absent:
+<step n="8" name="leads-init">Initialize `./analysis/leads.md` if absent:
 ```
-| lead_id | evidence_id | domain | hypothesis | pointer | priority | status |
-|---------|-------------|--------|------------|---------|----------|--------|
+| lead_id | evidence_id | domain | hypothesis | pointer | priority | status | notes |
+|---------|-------------|--------|------------|---------|----------|--------|-------|
 ```
-(In `mode: blocked`, the planner already created `leads.md` with the `L-EXTRACT-DISK-NN` row.)</step>
+(In `mode: blocked`, the planner already created `leads.md` with the BLOCKED row.)</step>
 
-<step n="9">Intake gate: <rule ref="DISCIPLINE §J"/>. Run `bash .claude/skills/dfir-bootstrap/intake-check.sh`. On blank fields, run `bash .claude/skills/dfir-bootstrap/intake-interview.sh`. In TTY mode it prompts directly. In non-TTY mode it writes `./analysis/.intake-pending` and exits nonzero — return `INTAKE-PENDING` to the orchestrator and STOP. Never invent values.</step>
+<step n="9" name="intake">Intake gate: <rule ref="DISCIPLINE §J"/>. Run `bash .claude/skills/dfir-bootstrap/intake-check.sh`. On blank fields, run `bash .claude/skills/dfir-bootstrap/intake-interview.sh`. In TTY mode it prompts directly. In non-TTY mode it writes `./analysis/.intake-pending` and exits nonzero — return `INTAKE-PENDING` to the orchestrator and STOP. Never invent values.</step>
 
-<step n="10">Append to `./analysis/forensic_audit.log` via `audit.sh` per <rule ref="DISCIPLINE §A"/>. The first entry MUST contain `discipline_v3_loaded`. If the planner returned `sequential` or `blocked`, append a follow-up `extraction-plan` row whose result field names the mode (the planner already emitted its own `extraction-plan computed` row; this row is triage's acknowledgement).</step>
+<step n="10" name="audit">Append to `./analysis/forensic_audit.log` via `audit.sh` per <rule ref="DISCIPLINE §A"/>. The first entry MUST contain `discipline_v4_loaded`. If the extraction-plan returned `sequential` or `blocked`, append a follow-up `extraction-plan` row whose result field names the mode. The diskimage-plan and per-image mount helpers emit their own audit rows; triage adds a single summary row of `triage complete: N items, K disk-mounts`.</step>
 
 </protocol>
 
 <rules-binding>
-<rule ref="DISCIPLINE §A"/> — audit-log integrity, marker emission
+<rule ref="DISCIPLINE §A"/> — audit-log integrity, marker emission, exact-command audit rows
 <rule ref="DISCIPLINE §J"/> — intake-completeness gate
-<rule ref="DISCIPLINE §P-diskimage"/> — non-E01 conversion before manifesting
+<rule ref="DISCIPLINE §P-diskimage"/> — disk images mounted read-only via qemu-nbd; never converted
 </rules-binding>
 
 <outputs>
-- `./analysis/preflight.md`, `./analysis/extraction-plan.md`, `./analysis/manifest.md`, `./analysis/leads.md` (initialized)
-- `./working/` populated (bulk mode) or first-stage-only (sequential mode)
-- Audit-log rows in `./analysis/forensic_audit.log`
+- `./analysis/preflight.md`, `./analysis/extraction-plan.md`, `./analysis/diskimage-plan.md`, `./analysis/manifest.md`, `./analysis/leads.md` (initialized)
+- `./working/<bundle>/` populated (bulk mode) or first-stage-only (sequential mode)
+- `./working/mounts/<EV>/p<M>/` partition mounts for every disk image
+- `./working/mounts/.<EV>.mount.json` sentinels (chain-of-custody record)
+- Audit-log rows in `./analysis/forensic_audit.log` — every command exact-recorded
 </outputs>
 
 <return>
 Return to orchestrator (≤200 words):
 - Case ID; preflight summary listing only `SKILL_STATUS:` `RED` domains by label (do NOT cite dpkg `MISSING` rows); evidence count by type
 - Extraction plan mode (`bulk` / `sequential` / `blocked`) and pointer `./analysis/extraction-plan.md`. On `sequential`, name the staged archive. On `blocked`, cite `L-EXTRACT-DISK-NN`.
+- Disk-image mount summary: count of mounted images, each `<EV>` paired with format and `/dev/nbd<N>`. On any `L-MOUNT-DISK-NN` / `L-MOUNT-FAIL-NN` lead, cite it.
 - Pointer: `./analysis/manifest.md`
 - Unclassified items (when any), with the reason for each
 

--- a/.claude/skills/ORCHESTRATE.md
+++ b/.claude/skills/ORCHESTRATE.md
@@ -12,7 +12,7 @@ This skill binds the orchestrator to DISCIPLINE §A (audit-log integrity), §B
 surface), §I (no lead un-worked), §J (intake completeness), §K (ATT&CK
 tagging), §L (multi-evidence path encoding), §P-pcap, §P-diskimage, §P-priority,
 §P-yara, and §P-sigma. Every dispatched agent invocation MUST emit the marker
-`discipline_v3_loaded` in its return result; the orchestrator MUST verify
+`discipline_v4_loaded` in its return result; the orchestrator MUST verify
 that marker before treating the agent's output as authoritative.
 </rules-binding>
 
@@ -74,6 +74,9 @@ write it on first append.
 | Correlator gap (phase 4) | `L-CORR-NN` | `L-CORR-03` |
 | Correlator re-extraction (phase 4, sequential mode) | `L-EXTRACT-RE-NN` | `L-EXTRACT-RE-01` |
 | Bootstrap disk-pressure block (phase 1) | `L-EXTRACT-DISK-NN` | `L-EXTRACT-DISK-01` |
+| Disk-image mount block (phase 1) | `L-MOUNT-DISK-NN` | `L-MOUNT-DISK-01` |
+| Disk-image mount failure (phase 1) | `L-MOUNT-FAIL-NN` | `L-MOUNT-FAIL-01` |
+| Disk-mount manifest invariant (manifest-check) | `L-MOUNT-LEDGER-NN` | `L-MOUNT-LEDGER-01` |
 
 Each prefix is globally unique per source — parallel agents need no shared
 lock. `NN` is zero-padded and counter-scoped to the invocation.
@@ -81,12 +84,12 @@ lock. `NN` is zero-padded and counter-scoped to the invocation.
 <protocol name="Forward dispatch">
 
 <phase n="1" name="Triage" mode="blocking">
-  <step n="1">Invoke `dfir-triage` with case ID and evidence path. Triage runs `extraction-plan.sh` before `case-init.sh`; the resulting `./analysis/extraction-plan.md` decides bulk vs. sequential staging.</step>
+  <step n="1">Invoke `dfir-triage` with case ID and evidence path. Triage runs `extraction-plan.sh` → `case-init.sh` (extraction) → `diskimage-plan.sh` → `diskimage-mount.sh` per disk image → `case-init.sh` again (sentinel sweep). The two plan files (`./analysis/extraction-plan.md`, `./analysis/diskimage-plan.md`) decide bulk vs. sequential staging together.</step>
   <step n="2">On return, read `analysis/manifest.md` headers only.</step>
-  <step n="3">Read the `Mode` field of `./analysis/extraction-plan.md` and branch:
-    - `bulk` → advance to Phase 2.
-    - `sequential` → enter `<sequential-extraction>` (below) to drive Phases 2/3 stage-by-stage. Do NOT fan out a single Phase 2 wave across all archives.
-    - `blocked` → surface the `L-EXTRACT-DISK-NN` lead (planner appended a BLOCKED row to `leads.md`) and stop. Operator frees disk or remounts before any further phase runs.
+  <step n="3">Read the `Mode` field of BOTH `./analysis/extraction-plan.md` AND `./analysis/diskimage-plan.md`; the most-restrictive mode wins (`blocked` > `sequential` > `bulk`):
+    - `bulk` (both) → advance to Phase 2.
+    - `sequential` (either) → enter `<sequential-extraction>` (below) to drive Phases 2/3 stage-by-stage. Do NOT fan out a single Phase 2 wave across all archives.
+    - `blocked` (either) → surface the BLOCKED lead (`L-EXTRACT-DISK-NN`, `L-MOUNT-DISK-NN`, or `L-MOUNT-FAIL-NN`) and stop. Operator addresses the gap before any further phase runs.
   </step>
 </phase>
 
@@ -109,7 +112,7 @@ lock. `NN` is zero-padded and counter-scoped to the invocation.
   1. **Extract** stage `N` if not yet on disk (single-element evidence subdir to case-init's bundle loop, or reuse triage's archive-specific extract). Tree at `./working/<basename>/`. Audit: `[disk] stage N: extract <archive>` via `audit.sh`.
   2. **Survey** — Phase 2 fan-out ONLY for `(stage-N evidence × applicable domains)`. Other stages remain unexpanded; surveyor MUST NOT touch them.
   3. **Investigate** — Phase 3 wave ONLY on `leads.md` rows from stage `N`'s surveys (`L-<EVID-of-stage-N>-...`). Honor the lead terminal-status invariant before advancing.
-  4. **Cleanup** — once stage `N`'s investigators settle, run `bash .claude/skills/dfir-bootstrap/extraction-cleanup.sh <basename-of-stage-N>`. Helper deletes ONLY `./working/<basename>/`; `./analysis/<domain>/`, `./exports/**`, `./analysis/manifest.md`, `./analysis/leads.md` preserved. Helper writes its own audit row; orchestrator ALSO writes `[disk] stage N: cleanup <archive> deleted=<N> files`.
+  4. **Cleanup** — once stage `N`'s investigators settle, run `bash .claude/skills/dfir-bootstrap/extraction-cleanup.sh <basename-of-stage-N>`. Helper FIRST calls `diskimage-unmount.sh <EV>` for any `<EV>` whose source path lives under `./working/<basename>/` (refuses to delete if any unmount fails), THEN deletes `./working/<basename>/`. `./analysis/<domain>/`, `./exports/**`, `./analysis/manifest.md`, `./analysis/leads.md`, and the disk-mount sentinels (now `mounted=false`) are preserved. Helper writes its own audit row; orchestrator ALSO writes `[disk] stage N: cleanup <archive> deleted=<N> files`.
   5. **Advance** — increment `N`. `N <= K` repeats from step 1; else proceed to Phase 4.
 
   `L-EXTRACT-RE-NN` re-extraction leads (correlator-driven; Phase 4) trigger an additional cycle: re-extract the named archive (when the lead names a path subset, restrict via `unzip <archive> "<subset>/*"` or `tar --wildcards`), run a scoped Phase 2/3 mini-wave, then call `extraction-cleanup.sh`.

--- a/.claude/skills/TRIAGE.md
+++ b/.claude/skills/TRIAGE.md
@@ -21,7 +21,7 @@ Binds DISCIPLINE §A (audit-log integrity), §B (headline revalidation), §F
 (lead surface), §I (no lead un-worked), §J (intake completeness), §K
 (ATT&CK tagging), §L (multi-evidence path encoding), §P-pcap, §P-diskimage,
 §P-priority, §P-yara, §P-sigma. Every audit-log write goes through `audit.sh`. Every
-pivot emits the marker `discipline_v3_loaded` in its action context.
+pivot emits the marker `discipline_v4_loaded` in its action context.
 </rules-binding>
 
 ## Operating philosophy

--- a/.claude/skills/dfir-bootstrap/SKILL.md
+++ b/.claude/skills/dfir-bootstrap/SKILL.md
@@ -433,7 +433,7 @@ grep -iE "usbstor|disk&ven" ./analysis/windows-artifacts/hives/SYSTEM.strings.tx
 - The DISCIPLINE.md rules (`.claude/skills/dfir-discipline/DISCIPLINE.md`) are
   loaded by every phase agent prompt with a `MANDATORY:` line. The first
   audit-log entry of each agent invocation includes the marker
-  `discipline_v3_loaded` as a self-attestation; bump the version (and update
+  `discipline_v4_loaded` as a self-attestation; bump the version (and update
   every agent prompt simultaneously) when the rules change substantively.
 - Bundle expansion in case-init.sh is disk-bounded: if the estimated
   expanded size of an archive exceeds 50% of free disk, the bundle is

--- a/.claude/skills/dfir-bootstrap/case-init.sh
+++ b/.claude/skills/dfir-bootstrap/case-init.sh
@@ -77,6 +77,7 @@ dirs=(
     "./analysis/sigma/jsonl"
     "./analysis/sigma/hits"
     "./working"
+    "./working/mounts"
     "./exports"
     # Canonical exports/ taxonomy — see dfir-discipline/DISCIPLINE.md
     # "Layer model" subsection. Pre-scaffolded so domain skills do not
@@ -581,6 +582,70 @@ if [[ -d "$EVIDENCE_DIR" ]]; then
     fi
 
     echo "[case-init] evidence manifest updated -> $MANIFEST (walk=${walk_count}, rows_appended=${rows_appended_this_run})"
+fi
+
+# ---------- disk-image mount sentinel sweep ----------
+# Disk images mounted via diskimage-mount.sh leave a sentinel JSON at
+# ./working/mounts/.<EV>.mount.json. Each sentinel maps an existing
+# evidence-blob row to a /dev/nbd<N> byte stream (the final-working-artifact
+# equivalent under DISCIPLINE §P-diskimage). For each sentinel that does NOT
+# yet have a `disk-mount` row in manifest.md, append one. Idempotent — safe
+# to re-run when triage adds more mounts.
+MOUNTS_DIR="./working/mounts"
+if [[ -d "$MOUNTS_DIR" ]]; then
+    shopt -s nullglob
+    mount_rows_appended=0
+    for sentinel in "${MOUNTS_DIR}"/.*.mount.json; do
+        [[ -f "$sentinel" ]] || continue
+        base="$(basename "$sentinel")"
+        ev="${base#.}"; ev="${ev%.mount.json}"
+        [[ "$ev" =~ ^EV[0-9]{2,}$ ]] || continue
+
+        # Skip if a disk-mount row already exists for this EV.
+        if grep -qE "^\| ${ev}-MOUNT \| " "$MANIFEST" 2>/dev/null; then
+            continue
+        fi
+
+        # Read sentinel fields (cheap awk/grep, no jq dependency).
+        nbd_sha="$(grep -oE '"nbd_byte_sha256":[[:space:]]*"[^"]+"' "$sentinel" 2>/dev/null \
+                   | head -1 | sed -E 's/.*"nbd_byte_sha256":[[:space:]]*"([^"]+)".*/\1/')"
+        src_sha="$(grep -oE '"source_sha256":[[:space:]]*"[^"]+"' "$sentinel" 2>/dev/null \
+                   | head -1 | sed -E 's/.*"source_sha256":[[:space:]]*"([^"]+)".*/\1/')"
+        fmt="$(grep -oE '"format":[[:space:]]*"[^"]+"' "$sentinel" 2>/dev/null \
+                | head -1 | sed -E 's/.*"format":[[:space:]]*"([^"]+)".*/\1/')"
+        nbd_dev="$(grep -oE '"nbd_device":[[:space:]]*"[^"]+"' "$sentinel" 2>/dev/null \
+                   | head -1 | sed -E 's/.*"nbd_device":[[:space:]]*"([^"]+)".*/\1/')"
+        src_rel="$(grep -oE '"source_relpath":[[:space:]]*"[^"]+"' "$sentinel" 2>/dev/null \
+                   | head -1 | sed -E 's/.*"source_relpath":[[:space:]]*"([^"]+)".*/\1/')"
+        adapter="$(grep -oE '"adapter_chain":[[:space:]]*"[^"]+"' "$sentinel" 2>/dev/null \
+                   | head -1 | sed -E 's/.*"adapter_chain":[[:space:]]*"([^"]+)".*/\1/')"
+        mounts_csv="$(grep -oE '"mount_points":[[:space:]]*\[[^]]*\]' "$sentinel" 2>/dev/null \
+                      | head -1 | grep -oE '"[^"]+"' | tr -d '"' | paste -sd, -)"
+
+        # Refuse to write the row if either hash is empty — that's an
+        # incomplete sentinel from a failed mount run; force re-mount.
+        if [[ -z "$nbd_sha" || -z "$src_sha" ]]; then
+            bash "$AUDIT_SH" "case-init mount-sentinel-incomplete" \
+                "sentinel=${sentinel} src_sha=${src_sha:-empty} nbd_sha=${nbd_sha:-empty}" \
+                "operator: re-run diskimage-mount.sh ${ev}" >/dev/null 2>&1 || true
+            echo "[case-init] WARN: incomplete mount sentinel for $ev — skipping disk-mount row" >&2
+            continue
+        fi
+
+        # Compose notes column with adapter chain + mount points + nbd byte hash.
+        notes_field="adapter=${adapter}; mount-points=${mounts_csv:-none}; nbd-byte-sha256=${nbd_sha}; nbd=${nbd_dev}; format=${fmt}"
+        # We use ev_id "<EV>-MOUNT" so the manifest row is unique per EV
+        # and easily greppable (manifest-check.sh keys off this prefix).
+        append_manifest_row "${ev}-MOUNT" "$(basename "$src_rel")" "$nbd_dev" \
+            "disk-mount" "0" "$nbd_sha" "$ev" "$notes_field"
+        mount_rows_appended=$((mount_rows_appended + 1))
+        bash "$AUDIT_SH" "case-init mount-sentinel" \
+            "appended disk-mount row for $ev (format=${fmt}, nbd-sha=${nbd_sha:0:16})" \
+            "surveyor reads from mount-points or ${nbd_dev}" >/dev/null 2>&1 || true
+    done
+    if [[ "$mount_rows_appended" -gt 0 ]]; then
+        echo "[case-init] disk-mount manifest rows appended: $mount_rows_appended"
+    fi
 fi
 
 # ---------- 00_intake.md ----------

--- a/.claude/skills/dfir-bootstrap/diskimage-mount.sh
+++ b/.claude/skills/dfir-bootstrap/diskimage-mount.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# diskimage-mount.sh -- canonical disk-image mount helper per
+# DISCIPLINE §P-diskimage.
+#
+# Usage: bash diskimage-mount.sh <source-relpath> <ev-id>
+#
+#   <source-relpath>  path under ./evidence/ or ./working/ (relative or
+#                     project-relative — the helper resolves to abs)
+#   <ev-id>           evidence_id slot (EV01, EV02, ...). Caller is
+#                     responsible for selecting an unused slot.
+#
+# Pipeline (uniform across formats; format detection only chooses qemu-nbd
+# -f flag and whether ewfmount is needed first):
+#
+#   1. qemu-img info <source>                        # detection
+#   2. lsmod | grep -q '^nbd' || modprobe nbd ...    # bootstrap (idempotent)
+#   3. ewfmount <source> <ewfmount-dir>/             # E01 only
+#   4. qemu-nbd --read-only --cache=none --format=<fmt> --connect=/dev/nbdN <source>
+#   5. mmls /dev/nbdN > ./analysis/filesystem/mmls-<EV>.txt
+#   6. mount -o ro,noload /dev/nbdNpM ./working/mounts/<EV>/pM   # per partition
+#   7. sha256sum <source>                            # original-artifact hash
+#   8. sha256sum /dev/nbdN                           # mount-source byte stream
+#   9. write sentinel ./working/mounts/.<ev>.mount.json
+#  10. (on every exit, via trap)
+#       umount each partition mount; qemu-nbd --disconnect; fusermount -u <ewfmount-dir>
+#
+# Every command in the pipeline emits ONE exact-command audit row via
+# audit.sh per DISCIPLINE §A.1 + the command-documentation contract in
+# §P-diskimage. Investigators can replay the case from the audit log
+# alone.
+#
+# Idempotent: if the sentinel exists and the recorded /dev/nbdN is still
+# attached to the same source, the helper short-circuits and exits 0
+# without re-mounting. Callers re-running this script after a clean
+# unmount get a fresh mount cycle.
+#
+# Failure handling: on any nonzero pipeline step, the EXIT trap detaches
+# every layer the helper attached so far (umount, qemu-nbd --disconnect,
+# fusermount -u), appends an L-MOUNT-FAIL-NN BLOCKED lead, and exits 1.
+# Encrypted sources BLOCK before attach with L-MOUNT-DISK-NN.
+#
+# Hashing contract:
+#   - source sha256       -- ALWAYS (skipped if already in manifest.md)
+#   - /dev/nbdN sha256    -- ALWAYS (the final-working-artifact equivalent)
+#   - mount-tree files    -- NEVER (survey-hash-on-read.sh handles those at touch time)
+#   - ewfmount intermediate /<ewf-dir>/ewf1 -- NEVER (chain-of-custody event audited only)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+AUDIT_SH="${SCRIPT_DIR}/audit.sh"
+
+SOURCE_REL="${1:-}"
+EV_ID="${2:-}"
+
+if [[ -z "$SOURCE_REL" || -z "$EV_ID" ]]; then
+    echo "usage: diskimage-mount.sh <source-relpath> <ev-id>" >&2
+    exit 2
+fi
+
+if [[ ! "$EV_ID" =~ ^EV[0-9]{2,}$ ]]; then
+    echo "diskimage-mount: ev-id must match EV[0-9]{2,} (got: $EV_ID)" >&2
+    exit 2
+fi
+
+# Resolve source to an absolute path (qemu-nbd needs it).
+if [[ "$SOURCE_REL" = /* ]]; then
+    SOURCE_ABS="$SOURCE_REL"
+else
+    SOURCE_ABS="$(readlink -f "$SOURCE_REL" 2>/dev/null || echo "")"
+fi
+if [[ -z "$SOURCE_ABS" || ! -f "$SOURCE_ABS" ]]; then
+    echo "diskimage-mount: source not found: $SOURCE_REL" >&2
+    exit 2
+fi
+
+MOUNT_BASE="./working/mounts/${EV_ID}"
+EWFMOUNT_DIR="${MOUNT_BASE}/.ewf"
+SENTINEL="./working/mounts/.${EV_ID}.mount.json"
+LEADS="./analysis/leads.md"
+
+mkdir -p "$MOUNT_BASE"
+mkdir -p ./analysis/filesystem
+
+# ---- audit helper ----
+emit_audit() {
+    # emit_audit "<phase>: <verb>" "<exact cmd line>" "<exit>" "<extras>" "<next step>"
+    local phase="$1" cmd="$2" rc="$3" extras="$4" nxt="$5"
+    local result="cmd: ${cmd}; exit=${rc}"
+    [[ -n "$extras" ]] && result+="; ${extras}"
+    if [[ -x "$AUDIT_SH" ]]; then
+        bash "$AUDIT_SH" "$phase" "$result" "$nxt" >/dev/null 2>&1 || true
+    fi
+}
+
+# ---- leads helpers (mirror extraction-plan / case-init patterns) ----
+ensure_leads_md() {
+    if [[ ! -f "$LEADS" ]]; then
+        mkdir -p ./analysis
+        cat > "$LEADS" <<'EOF'
+| lead_id | evidence_id | domain | hypothesis | pointer | priority | status | notes |
+|---------|-------------|--------|------------|---------|----------|--------|-------|
+EOF
+    fi
+}
+next_lead_id() {
+    local prefix="$1" last_n
+    last_n="$(grep -oE "\\| ${prefix}-[0-9]+" "$LEADS" 2>/dev/null \
+              | grep -oE '[0-9]+$' | sort -n | tail -1)"
+    if [[ -z "$last_n" ]]; then printf '%s-01' "$prefix"
+    else printf '%s-%02d' "$prefix" $((10#$last_n + 1)); fi
+}
+append_blocked_lead() {
+    local prefix="$1" ev="$2" hyp="$3" pointer="$4" notes="$5"
+    ensure_leads_md
+    local hyp_safe="${hyp//|/\\|}" notes_safe="${notes//|/\\|}"
+    if grep -qF "$hyp_safe" "$LEADS" 2>/dev/null; then
+        grep -F "$hyp_safe" "$LEADS" 2>/dev/null \
+            | grep -oE "\\| ${prefix}-[0-9]+" | head -1 | tr -d '| '
+        return 0
+    fi
+    local lid; lid="$(next_lead_id "$prefix")"
+    printf '| %s | %s | bootstrap | %s | %s | high | blocked | %s |\n' \
+        "$lid" "$ev" "$hyp_safe" "$pointer" "$notes_safe" >> "$LEADS"
+    echo "$lid"
+}
+
+# ---- detach state (populated as we attach) ----
+PARTITIONS_MOUNTED=()
+NBD_ATTACHED=""
+EWFMOUNT_ATTACHED=""
+
+# Trap detaches every layer in reverse order on EVERY exit path,
+# including failures and signals. This is the chain-of-custody invariant:
+# we never leave a /dev/nbdN attached or a mount lingering.
+detach_all() {
+    local exit_code=$?
+    set +e
+
+    # 1. unmount filesystem partitions
+    for mp in "${PARTITIONS_MOUNTED[@]}"; do
+        if mountpoint -q "$mp" 2>/dev/null; then
+            local cmd="umount ${mp}"
+            sudo umount "$mp" 2>/dev/null
+            emit_audit "diskimage-mount: umount" "$cmd" "$?" "mountpoint=$mp" "qemu-nbd --disconnect"
+        fi
+    done
+
+    # 2. detach qemu-nbd
+    if [[ -n "$NBD_ATTACHED" ]]; then
+        local cmd="qemu-nbd --disconnect ${NBD_ATTACHED}"
+        sudo qemu-nbd --disconnect "$NBD_ATTACHED" 2>/dev/null
+        emit_audit "diskimage-mount: nbd-detach" "$cmd" "$?" "nbd=${NBD_ATTACHED}" "fusermount -u (E01) or done"
+    fi
+
+    # 3. unmount ewfmount FUSE layer (E01 only)
+    if [[ -n "$EWFMOUNT_ATTACHED" ]]; then
+        local cmd="fusermount -u ${EWFMOUNT_ATTACHED}"
+        fusermount -u "$EWFMOUNT_ATTACHED" 2>/dev/null
+        emit_audit "diskimage-mount: ewfmount-detach" "$cmd" "$?" "ewfdir=${EWFMOUNT_ATTACHED}" "done"
+    fi
+
+    exit "$exit_code"
+}
+trap detach_all EXIT
+
+# ---- step 1: detect format ----
+QEMU_INFO_OUT=""
+QEMU_INFO_RC=0
+if command -v qemu-img >/dev/null 2>&1; then
+    QEMU_INFO_OUT="$(qemu-img info "$SOURCE_ABS" 2>&1)"
+    QEMU_INFO_RC=$?
+    emit_audit "diskimage-mount: detect-format" \
+        "qemu-img info ${SOURCE_ABS}" "$QEMU_INFO_RC" \
+        "" "classify and pick adapter"
+fi
+
+KIND="unknown"
+ENC_FLAG=""
+if [[ "$QEMU_INFO_RC" -eq 0 ]]; then
+    QFMT="$(printf '%s\n' "$QEMU_INFO_OUT" | awk -F': ' '/^file format:/ {print $2; exit}')"
+    QENC="$(printf '%s\n' "$QEMU_INFO_OUT" | awk -F': ' '/^encrypted:/ {print $2; exit}')"
+    [[ "$QENC" == "yes" ]] && ENC_FLAG="encrypted"
+    case "$QFMT" in
+        raw|vmdk|vpc|vhdx|qcow2) KIND="$QFMT" ;;
+    esac
+fi
+# E01 detection via ewfinfo (more authoritative than qemu-img for E01)
+if [[ "$KIND" == "unknown" || "$KIND" == "raw" ]]; then
+    if command -v ewfinfo >/dev/null 2>&1 && ewfinfo "$SOURCE_ABS" >/dev/null 2>&1; then
+        emit_audit "diskimage-mount: ewfinfo-probe" \
+            "ewfinfo ${SOURCE_ABS}" "0" "" "classify as e01"
+        KIND="e01"
+    fi
+fi
+
+if [[ -n "$ENC_FLAG" ]]; then
+    hyp="Encrypted disk image: ${SOURCE_REL} requires decryption key"
+    notes="suggested-fix=provide-key; format=${KIND}; re-run after key supplied"
+    lid="$(append_blocked_lead "L-MOUNT-DISK" "$EV_ID" "$hyp" "analysis/manifest.md" "$notes")"
+    emit_audit "diskimage-mount: BLOCKED encrypted" \
+        "qemu-img info reported encrypted=yes" "0" "lead=${lid}" "operator: provide key, re-run"
+    echo "diskimage-mount: BLOCKED — encrypted source ($SOURCE_REL); lead=${lid}" >&2
+    exit 1
+fi
+
+if [[ "$KIND" == "unknown" ]]; then
+    hyp="Disk image format unknown for ${SOURCE_REL}: qemu-img info + ewfinfo both failed to classify"
+    notes="suggested-fix=add-format-support; tool-needed=qemu-img-or-ewfinfo; investigate manually"
+    lid="$(append_blocked_lead "L-MOUNT-FAIL" "$EV_ID" "$hyp" "analysis/manifest.md" "$notes")"
+    emit_audit "diskimage-mount: BLOCKED unknown-format" \
+        "classify_diskimage returned unknown" "1" "lead=${lid}" "operator: classify manually"
+    echo "diskimage-mount: BLOCKED — format unknown for $SOURCE_REL; lead=${lid}" >&2
+    exit 1
+fi
+
+# ---- short-circuit: existing sentinel + still-attached nbd ----
+if [[ -f "$SENTINEL" ]]; then
+    PRIOR_NBD="$(grep -oE '"nbd-device": *"[^"]+"' "$SENTINEL" 2>/dev/null \
+                | head -1 | sed 's/.*"\(\/dev\/nbd[0-9]\+\)".*/\1/')"
+    if [[ -n "$PRIOR_NBD" && -b "$PRIOR_NBD" ]]; then
+        # Probe whether nbd is currently bound to our source
+        if sudo nbd-client -c "$PRIOR_NBD" >/dev/null 2>&1 \
+           || [[ -s "/sys/block/$(basename "$PRIOR_NBD")/size" ]]; then
+            emit_audit "diskimage-mount: idempotent-skip" \
+                "sentinel ${SENTINEL} present; nbd ${PRIOR_NBD} still attached" \
+                "0" "ev=${EV_ID} format=${KIND}" "no-op"
+            echo "diskimage-mount: $EV_ID already mounted at $PRIOR_NBD (sentinel hit)"
+            # Suppress the trap from detaching — we did not attach this round.
+            trap - EXIT
+            exit 0
+        fi
+    fi
+fi
+
+# ---- step 2: bootstrap nbd kernel module ----
+NBD_OK=0
+if lsmod 2>/dev/null | grep -q '^nbd'; then
+    NBD_OK=1
+    emit_audit "diskimage-mount: nbd-probe" \
+        "lsmod | grep -q '^nbd'" "0" "module=loaded" "qemu-nbd attach"
+else
+    emit_audit "diskimage-mount: nbd-probe" \
+        "lsmod | grep -q '^nbd'" "1" "module=absent" "modprobe nbd max_part=16"
+    if sudo modprobe nbd max_part=16 2>/dev/null; then
+        NBD_OK=1
+        emit_audit "diskimage-mount: modprobe-nbd" \
+            "modprobe nbd max_part=16" "0" "module=loaded" "qemu-nbd attach"
+    else
+        emit_audit "diskimage-mount: modprobe-nbd" \
+            "modprobe nbd max_part=16" "$?" "module=load-failed" "operator: kernel nbd missing"
+    fi
+fi
+if [[ "$NBD_OK" -ne 1 ]]; then
+    hyp="nbd kernel module unavailable on host; cannot attach $SOURCE_REL"
+    notes="suggested-fix=install-package; tool-needed=kernel-nbd-module"
+    lid="$(append_blocked_lead "L-MOUNT-FAIL" "$EV_ID" "$hyp" "analysis/manifest.md" "$notes")"
+    echo "diskimage-mount: BLOCKED — nbd kernel module not loadable; lead=${lid}" >&2
+    exit 1
+fi
+
+# ---- pick a free /dev/nbd<N> ----
+pick_nbd() {
+    local n=0
+    while [[ $n -lt 16 ]]; do
+        local dev="/dev/nbd${n}"
+        if [[ ! -b "$dev" ]]; then
+            n=$((n + 1)); continue
+        fi
+        # /sys/block/nbdN/size == 0 means unused
+        local size=0
+        size="$(cat "/sys/block/nbd${n}/size" 2>/dev/null || echo 0)"
+        if [[ "$size" == "0" ]]; then
+            echo "$dev"
+            return 0
+        fi
+        n=$((n + 1))
+    done
+    echo ""
+}
+NBD_DEV="$(pick_nbd)"
+if [[ -z "$NBD_DEV" ]]; then
+    hyp="No free /dev/nbd[0-15] available; all 16 nbd slots in use"
+    notes="suggested-fix=detach-stale-nbd-or-modprobe-with-larger-nbds-max"
+    lid="$(append_blocked_lead "L-MOUNT-FAIL" "$EV_ID" "$hyp" "analysis/manifest.md" "$notes")"
+    echo "diskimage-mount: BLOCKED — no free nbd device; lead=${lid}" >&2
+    exit 1
+fi
+
+# ---- step 3: ewfmount (E01 only) ----
+QEMU_SOURCE="$SOURCE_ABS"
+QEMU_FMT=""
+case "$KIND" in
+    e01)
+        mkdir -p "$EWFMOUNT_DIR"
+        local_cmd="ewfmount ${SOURCE_ABS} ${EWFMOUNT_DIR}"
+        ewfmount "$SOURCE_ABS" "$EWFMOUNT_DIR" 2>/dev/null
+        rc=$?
+        emit_audit "diskimage-mount: ewfmount" "$local_cmd" "$rc" "ewfdir=${EWFMOUNT_DIR}" "qemu-nbd attach"
+        if [[ "$rc" -ne 0 || ! -e "${EWFMOUNT_DIR}/ewf1" ]]; then
+            hyp="ewfmount failed for ${SOURCE_REL} (E01 source); cannot expose raw byte stream"
+            notes="suggested-fix=verify-libewf-tools; cmd=${local_cmd}; rc=${rc}"
+            lid="$(append_blocked_lead "L-MOUNT-FAIL" "$EV_ID" "$hyp" "analysis/manifest.md" "$notes")"
+            echo "diskimage-mount: BLOCKED — ewfmount failed for $SOURCE_REL; lead=${lid}" >&2
+            exit 1
+        fi
+        EWFMOUNT_ATTACHED="$EWFMOUNT_DIR"
+        QEMU_SOURCE="${EWFMOUNT_DIR}/ewf1"
+        QEMU_FMT="raw"
+        ;;
+    raw)        QEMU_FMT="raw"   ;;
+    vmdk)       QEMU_FMT="vmdk"  ;;
+    vpc)        QEMU_FMT="vpc"   ;;
+    vhdx)       QEMU_FMT="vhdx"  ;;
+    qcow2)      QEMU_FMT="qcow2" ;;
+esac
+
+# ---- step 4: qemu-nbd attach ----
+ATTACH_CMD="qemu-nbd --read-only --cache=none --format=${QEMU_FMT} --connect=${NBD_DEV} ${QEMU_SOURCE}"
+sudo qemu-nbd --read-only --cache=none --format="$QEMU_FMT" --connect="$NBD_DEV" "$QEMU_SOURCE" 2>/dev/null
+rc=$?
+emit_audit "diskimage-mount: nbd-attach" "$ATTACH_CMD" "$rc" "nbd=${NBD_DEV} format=${QEMU_FMT}" "mmls partition table"
+if [[ "$rc" -ne 0 ]]; then
+    hyp="qemu-nbd attach failed for ${SOURCE_REL} (format=${KIND}); see audit log for stderr"
+    notes="suggested-fix=verify-source-integrity; cmd=${ATTACH_CMD}; rc=${rc}"
+    lid="$(append_blocked_lead "L-MOUNT-FAIL" "$EV_ID" "$hyp" "analysis/manifest.md" "$notes")"
+    echo "diskimage-mount: BLOCKED — qemu-nbd attach failed for $SOURCE_REL; lead=${lid}" >&2
+    exit 1
+fi
+NBD_ATTACHED="$NBD_DEV"
+
+# Wait for the kernel to populate /sys/block/<nbdN>/size
+sleep_count=0
+while [[ "$sleep_count" -lt 20 ]]; do
+    sz="$(cat "/sys/block/$(basename "$NBD_DEV")/size" 2>/dev/null || echo 0)"
+    [[ "$sz" != "0" ]] && break
+    sleep 0.1
+    sleep_count=$((sleep_count + 1))
+done
+
+# ---- step 5: mmls (partition layout) ----
+MMLS_OUT="./analysis/filesystem/mmls-${EV_ID}.txt"
+MMLS_CMD="mmls ${NBD_DEV}"
+mmls "$NBD_DEV" > "$MMLS_OUT" 2>/dev/null
+rc=$?
+emit_audit "diskimage-mount: mmls" "$MMLS_CMD > $MMLS_OUT" "$rc" "out=${MMLS_OUT}" "mount partitions"
+# mmls non-zero is non-fatal (some images have no partition table; we still
+# attempt to mount /dev/nbdN as a single filesystem).
+
+# ---- step 6: mount partitions ----
+# Parse mmls output: rows starting with a digit are partition slots.
+# Format: "<slot>:  <start>  <end>  <length>  <description>"
+declare -a PARTS_TO_MOUNT=()
+if [[ "$rc" -eq 0 && -s "$MMLS_OUT" ]]; then
+    while read -r slot _; do
+        [[ "$slot" =~ ^[0-9]{3}: ]] || continue
+        # mmls slot 000 typically maps to /dev/nbdNp1, but partitions
+        # without a filesystem (e.g. extended container, unallocated) need
+        # filtering. Use file -s on each /dev/nbdNp* the kernel created.
+        :
+    done < "$MMLS_OUT"
+fi
+# Walk every /dev/nbdNpM the kernel created; let mount succeed where it can.
+for partdev in "${NBD_DEV}"p*; do
+    [[ -b "$partdev" ]] || continue
+    pnum="${partdev##*p}"
+    mp="${MOUNT_BASE}/p${pnum}"
+    mkdir -p "$mp"
+    # Attempt mount; ro,noload prevents journal replay on ext.
+    MOUNT_CMD="mount -o ro,noload ${partdev} ${mp}"
+    sudo mount -o ro,noload "$partdev" "$mp" 2>/dev/null
+    mrc=$?
+    if [[ "$mrc" -ne 0 ]]; then
+        # Retry without noload (NTFS / FAT don't accept noload)
+        MOUNT_CMD="mount -o ro ${partdev} ${mp}"
+        sudo mount -o ro "$partdev" "$mp" 2>/dev/null
+        mrc=$?
+    fi
+    if [[ "$mrc" -eq 0 ]]; then
+        PARTITIONS_MOUNTED+=("$mp")
+        FS_TYPE="$(findmnt -n -o FSTYPE "$mp" 2>/dev/null || echo unknown)"
+        emit_audit "diskimage-mount: partition-mount" \
+            "$MOUNT_CMD" "0" "fs=${FS_TYPE} part=${partdev}" "next partition or hash"
+    else
+        rmdir "$mp" 2>/dev/null || true
+        emit_audit "diskimage-mount: partition-mount" \
+            "$MOUNT_CMD" "$mrc" "part=${partdev} skip=true" "filesystem unsupported or unallocated; continue"
+    fi
+done
+
+# ---- step 7: source sha256 ----
+SRC_HASH_CMD="sha256sum ${SOURCE_ABS}"
+SRC_SHA="$(sha256sum "$SOURCE_ABS" 2>/dev/null | awk '{print $1}')"
+emit_audit "diskimage-mount: source-hash" "$SRC_HASH_CMD" "$?" "sha256=${SRC_SHA}" "nbd-stream hash"
+
+# ---- step 8: /dev/nbdN sha256 (the final-working-artifact equivalent) ----
+NBD_HASH_CMD="sha256sum ${NBD_DEV}"
+NBD_SHA="$(sudo sha256sum "$NBD_DEV" 2>/dev/null | awk '{print $1}')"
+emit_audit "diskimage-mount: nbd-stream-hash" "$NBD_HASH_CMD" "$?" "sha256=${NBD_SHA} nbd=${NBD_DEV}" "write sentinel"
+
+if [[ -z "$NBD_SHA" ]]; then
+    hyp="sha256sum of ${NBD_DEV} returned empty for ${SOURCE_REL}; chain-of-custody invariant violated"
+    notes="suggested-fix=re-run-mount; verify nbd kernel module"
+    lid="$(append_blocked_lead "L-MOUNT-FAIL" "$EV_ID" "$hyp" "analysis/manifest.md" "$notes")"
+    echo "diskimage-mount: BLOCKED — empty nbd sha256; lead=${lid}" >&2
+    exit 1
+fi
+
+# ---- step 9: write sentinel ----
+UTC_NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+QEMU_NBD_VER="$(qemu-nbd --version 2>/dev/null | head -1 | sed 's/"/\\"/g' || echo unknown)"
+EWFMOUNT_VER=""
+if [[ "$KIND" == "e01" ]]; then
+    EWFMOUNT_VER="$(ewfmount -V 2>&1 | head -1 | sed 's/"/\\"/g' || echo unknown)"
+fi
+MOUNT_LIST_JSON="["
+first=1
+for mp in "${PARTITIONS_MOUNTED[@]:-}"; do
+    [[ -z "$mp" ]] && continue
+    if [[ "$first" -eq 1 ]]; then first=0; else MOUNT_LIST_JSON+=", "; fi
+    MOUNT_LIST_JSON+="\"${mp}\""
+done
+MOUNT_LIST_JSON+="]"
+
+cat > "$SENTINEL" <<EOF
+{
+  "schema": "diskimage-mount/v1",
+  "ev_id": "${EV_ID}",
+  "source_relpath": "${SOURCE_REL}",
+  "source_abspath": "${SOURCE_ABS}",
+  "format": "${KIND}",
+  "qemu_format": "${QEMU_FMT}",
+  "adapter_chain": "$(/bin/echo -n "$KIND" | grep -q '^e01$' && echo 'ewfmount -> qemu-nbd -f raw -> mount -o ro,noload' || echo "qemu-nbd -f ${QEMU_FMT} -> mount -o ro,noload")",
+  "ewfmount_dir": "${EWFMOUNT_ATTACHED}",
+  "nbd_device": "${NBD_DEV}",
+  "mount_points": ${MOUNT_LIST_JSON},
+  "source_sha256": "${SRC_SHA}",
+  "nbd_byte_sha256": "${NBD_SHA}",
+  "tool_versions": {
+    "qemu-nbd": "${QEMU_NBD_VER}",
+    "ewfmount": "${EWFMOUNT_VER}"
+  },
+  "ts_attach": "${UTC_NOW}",
+  "ts_detach": null,
+  "mounted": true
+}
+EOF
+emit_audit "diskimage-mount: sentinel-write" \
+    "Write ${SENTINEL}" "0" \
+    "ev=${EV_ID} format=${KIND} nbd=${NBD_DEV} mounts=${#PARTITIONS_MOUNTED[@]} src-sha=${SRC_SHA:0:16} nbd-sha=${NBD_SHA:0:16}" \
+    "case-init.sh appends manifest rows (blob + disk-mount)"
+
+# Successful exit — suppress the trap so we DO NOT detach. Mount persists
+# for downstream phases. diskimage-unmount.sh detaches when needed.
+trap - EXIT
+
+echo "diskimage-mount: $EV_ID mounted (format=${KIND}, nbd=${NBD_DEV}, partitions=${#PARTITIONS_MOUNTED[@]})"
+exit 0

--- a/.claude/skills/dfir-bootstrap/diskimage-plan.sh
+++ b/.claude/skills/dfir-bootstrap/diskimage-plan.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# diskimage-plan.sh -- disk-image discovery + mount planner.
+#
+# Walks ./evidence/ AND ./working/ depth-unbounded for disk images
+# (E01, raw/dd, vmdk, vhd, vhdx, qcow2). Detects format via qemu-img info
+# and ewfinfo, computes logical (virtual) size, records the canonical
+# adapter chain per DISCIPLINE §P-diskimage. Writes ./analysis/diskimage-plan.md.
+#
+# Mount layer consumes ~0 disk (qemu-nbd is a block-device facade);
+# headroom check covers only mount-metadata + audit-ledger overhead.
+# The mode tree mirrors extraction-plan.sh so the orchestrator can take
+# the most-restrictive of the two plans for the dispatch decision.
+#
+# Modes
+#   bulk        every disk image fits the small mount-overhead budget. Triage
+#               mounts every image in Phase 1.
+#   sequential  combined budget exceeds free, but every image fits alone.
+#               Orchestrator stages mount/dismount per disk image.
+#   blocked     a single image's mount overhead + headroom exceeds free
+#               disk, OR an encrypted image is detected without a key,
+#               OR a required tool (qemu-nbd / ewfmount) is missing.
+#               L-MOUNT-DISK-NN row appended to leads.md.
+#
+# Inputs (env)
+#   HEADROOM_PCT       default 20.
+#   MOUNT_OVERHEAD_MB  default 64. Reserved per disk image for mountpoint
+#                      bookkeeping, mmls output, sentinel JSON, audit rows.
+#
+# Output
+#   ./analysis/diskimage-plan.md  -- the plan (rewritten on every run)
+#   ./analysis/leads.md           -- appended L-MOUNT-DISK-NN row on blocked
+#   audit row                     -- "diskimage-plan computed: ..."
+#
+# Exit
+#   0   plan mode = bulk OR sequential
+#   1   plan mode = blocked
+#   2   misuse / preconditions wrong (no analysis dir, malformed env)
+#
+# Idempotency: re-running on the same evidence regenerates the same plan
+# file. Image ordering is deterministic (lexicographic by relative path).
+
+set -u
+
+EVIDENCE_DIR="./evidence"
+WORKING_DIR="./working"
+PLAN_FILE="./analysis/diskimage-plan.md"
+LEADS="./analysis/leads.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+AUDIT_SH="${SCRIPT_DIR}/audit.sh"
+HEADROOM_PCT="${HEADROOM_PCT:-20}"
+MOUNT_OVERHEAD_MB="${MOUNT_OVERHEAD_MB:-64}"
+
+# ---- preconditions ----
+if [[ ! -d "./analysis" ]]; then
+    echo "diskimage-plan: ./analysis not found (run from case workspace)" >&2
+    exit 2
+fi
+if [[ ! -d "$EVIDENCE_DIR" ]]; then
+    echo "diskimage-plan: $EVIDENCE_DIR not found" >&2
+    exit 2
+fi
+if ! [[ "$HEADROOM_PCT" =~ ^[0-9]+$ ]]; then
+    echo "diskimage-plan: HEADROOM_PCT must be a non-negative integer (got: $HEADROOM_PCT)" >&2
+    exit 2
+fi
+if ! [[ "$MOUNT_OVERHEAD_MB" =~ ^[0-9]+$ ]]; then
+    echo "diskimage-plan: MOUNT_OVERHEAD_MB must be a non-negative integer (got: $MOUNT_OVERHEAD_MB)" >&2
+    exit 2
+fi
+mkdir -p "./analysis"
+
+# ---- helpers ----
+hsize() { local b="$1"; numfmt --to=iec --suffix=B "$b" 2>/dev/null || echo "${b}B"; }
+
+# Classify by qemu-img info first (most authoritative for virtual disks),
+# fall back to ewfinfo for E01, then file -b for raw heuristics.
+# Echoes one of: e01 | raw | vmdk | vpc | vhdx | qcow2 | encrypted | unknown
+classify_diskimage() {
+    local f="$1" qfmt="" qenc="" ftype_raw=""
+
+    # E01 first — ewfinfo exit 0 is authoritative
+    if command -v ewfinfo >/dev/null 2>&1 && ewfinfo "$f" >/dev/null 2>&1; then
+        echo "e01"
+        return 0
+    fi
+
+    # qemu-img info — emits "file format: <fmt>" and "encrypted: yes" when set
+    if command -v qemu-img >/dev/null 2>&1; then
+        local qout
+        qout="$(qemu-img info "$f" 2>/dev/null || true)"
+        qfmt="$(printf '%s\n' "$qout" | awk -F': ' '/^file format:/ {print $2; exit}')"
+        qenc="$(printf '%s\n' "$qout" | awk -F': ' '/^encrypted:/ {print $2; exit}')"
+        if [[ "$qenc" == "yes" ]]; then
+            echo "encrypted"
+            return 0
+        fi
+        case "$qfmt" in
+            raw|vmdk|vpc|vhdx|qcow2)
+                echo "$qfmt"
+                return 0
+                ;;
+        esac
+    fi
+
+    # Last-resort heuristic for raw images via file(1) + extension.
+    ftype_raw="$(file -b "$f" 2>/dev/null || echo unknown)"
+    case "$ftype_raw" in
+        *"DOS/MBR boot sector"*|*"GPT partition table"*)
+            echo "raw"
+            return 0
+            ;;
+    esac
+    case "$f" in
+        *.dd|*.raw|*.img)
+            # Trust the extension when qemu-img wasn't decisive.
+            echo "raw"
+            return 0
+            ;;
+    esac
+
+    echo "unknown"
+    return 0
+}
+
+# Logical size: virtual size (qemu-img) for virtual formats; file size
+# (stat) for raw/E01. Echoes bytes; 0 on failure (caller treats as
+# unknown — does not block but does not contribute to the total either).
+logical_size() {
+    local f="$1" kind="$2" virt=""
+    case "$kind" in
+        vmdk|vpc|vhdx|qcow2)
+            if command -v qemu-img >/dev/null 2>&1; then
+                virt="$(qemu-img info "$f" 2>/dev/null \
+                        | awk -F'[()]' '/^virtual size:/ {print $2; exit}' \
+                        | awk '{print $1}')"
+                # virt is the byte count from "virtual size: X (NNN bytes)"
+                if [[ "$virt" =~ ^[0-9]+$ ]]; then
+                    echo "$virt"
+                    return 0
+                fi
+            fi
+            ;;
+    esac
+    stat -c%s "$f" 2>/dev/null || echo 0
+}
+
+# Adapter chain per DISCIPLINE §P-diskimage
+adapter_chain() {
+    local kind="$1"
+    case "$kind" in
+        e01)         echo "ewfmount -> qemu-nbd -f raw -> mount -o ro,noload" ;;
+        raw)         echo "qemu-nbd -f raw -> mount -o ro,noload" ;;
+        vmdk)        echo "qemu-nbd -f vmdk -> mount -o ro,noload" ;;
+        vpc)         echo "qemu-nbd -f vpc -> mount -o ro,noload" ;;
+        vhdx)        echo "qemu-nbd -f vhdx -> mount -o ro,noload" ;;
+        qcow2)       echo "qemu-nbd -f qcow2 -> mount -o ro,noload" ;;
+        encrypted)   echo "BLOCK: encrypted (provide-key)" ;;
+        unknown)     echo "BLOCK: format unknown" ;;
+    esac
+}
+
+# Helper: ensure leads.md exists with the canonical 8-column header.
+ensure_leads_md() {
+    if [[ ! -f "$LEADS" ]]; then
+        mkdir -p ./analysis
+        cat > "$LEADS" <<'EOF'
+| lead_id | evidence_id | domain | hypothesis | pointer | priority | status | notes |
+|---------|-------------|--------|------------|---------|----------|--------|-------|
+EOF
+    fi
+}
+
+# Pick the next L-<PREFIX>-NN id given a numeric prefix.
+next_lead_id() {
+    local prefix="$1"
+    local last_n
+    last_n="$(grep -oE "\\| ${prefix}-[0-9]+" "$LEADS" 2>/dev/null \
+              | grep -oE '[0-9]+$' | sort -n | tail -1)"
+    if [[ -z "$last_n" ]]; then
+        printf '%s-01' "$prefix"
+    else
+        printf '%s-%02d' "$prefix" $((10#$last_n + 1))
+    fi
+}
+
+# Append a BLOCKED lead row, idempotent on hypothesis match.
+append_blocked_lead() {
+    local prefix="$1" ev_id="$2" hypothesis="$3" pointer="$4" notes="$5"
+    ensure_leads_md
+    local hyp_safe="${hypothesis//|/\\|}"
+    local notes_safe="${notes//|/\\|}"
+    if grep -qF "$hyp_safe" "$LEADS" 2>/dev/null; then
+        local existing
+        existing="$(grep -F "$hyp_safe" "$LEADS" 2>/dev/null \
+                    | grep -oE "\\| ${prefix}-[0-9]+" | head -1 | tr -d '| ')"
+        echo "${existing:-${prefix}-??}"
+        return 0
+    fi
+    local lead_id
+    lead_id="$(next_lead_id "$prefix")"
+    printf '| %s | %s | bootstrap | %s | %s | high | blocked | %s |\n' \
+        "$lead_id" "$ev_id" "$hyp_safe" "$pointer" "$notes_safe" >> "$LEADS"
+    echo "$lead_id"
+}
+
+# ---- 1. enumerate disk images, deterministic order ----
+declare -a IMG_RELPATH=()
+declare -a IMG_KIND=()
+declare -a IMG_LOGICAL=()
+declare -a IMG_ADAPTER=()
+
+# Walk both evidence/ and working/ depth-unbounded. Disk images may be
+# nested inside extracted archives.
+declare -a search_roots=()
+[[ -d "$EVIDENCE_DIR" ]] && search_roots+=("$EVIDENCE_DIR")
+[[ -d "$WORKING_DIR" ]] && search_roots+=("$WORKING_DIR")
+
+# Skip ./working/mounts/ — those are the mount points themselves, not
+# new disk images to plan against.
+mapfile -d '' all_files < <(find "${search_roots[@]}" -mindepth 1 -type f \
+                            -not -path "$WORKING_DIR/mounts/*" \
+                            -print0 2>/dev/null \
+                          | LC_ALL=C sort -z)
+
+for f in "${all_files[@]}"; do
+    [[ -f "$f" ]] || continue
+
+    # Cheap pre-filter on extension to avoid running qemu-img on every
+    # bundle member. The classifier still re-checks via qemu-img/ewfinfo
+    # for files that pass the filter.
+    case "$f" in
+        *.E01|*.e01|*.Ex01|*.ex01|*.[eE]0[0-9][0-9]|*.dd|*.raw|*.img|*.vmdk|*.VMDK|*.vhd|*.VHD|*.vhdx|*.VHDX|*.qcow2|*.QCOW2)
+            ;;
+        *)
+            continue
+            ;;
+    esac
+
+    # Skip secondary segments of split E01 (only the first segment is the
+    # canonical entry; libewf chains the rest).
+    case "$f" in
+        *.E0[2-9]|*.E[1-9][0-9]|*.e0[2-9]|*.e[1-9][0-9])
+            continue
+            ;;
+    esac
+
+    kind="$(classify_diskimage "$f")"
+    [[ "$kind" == "unknown" ]] && continue
+
+    rel="${f#./}"
+    logical="$(logical_size "$f" "$kind")"
+    [[ -z "$logical" ]] && logical=0
+    adapter="$(adapter_chain "$kind")"
+
+    IMG_RELPATH+=("$rel")
+    IMG_KIND+=("$kind")
+    IMG_LOGICAL+=("$logical")
+    IMG_ADAPTER+=("$adapter")
+done
+
+IMG_COUNT="${#IMG_RELPATH[@]}"
+
+# ---- 2. compute totals + free disk ----
+# Mount overhead per image (small): mountpoint dirs, mmls output,
+# sentinel JSON, audit-row overhead. MOUNT_OVERHEAD_MB default 64.
+PER_IMAGE_OVERHEAD=$(( MOUNT_OVERHEAD_MB * 1024 * 1024 ))
+TOTAL_OVERHEAD=$(( IMG_COUNT * PER_IMAGE_OVERHEAD ))
+
+AVAIL_KB="$(df --output=avail "$WORKING_DIR" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+if [[ -z "$AVAIL_KB" || ! "$AVAIL_KB" =~ ^[0-9]+$ ]]; then
+    AVAIL_KB=0
+fi
+FREE_BYTES=$(( AVAIL_KB * 1024 ))
+
+HEADROOM_BYTES=$(( TOTAL_OVERHEAD * HEADROOM_PCT / 100 ))
+NEED_BYTES=$(( TOTAL_OVERHEAD + HEADROOM_BYTES ))
+
+# ---- 3. encrypted / unsupported pre-block check ----
+ENCRYPTED_HITS=0
+for k in "${IMG_KIND[@]:-}"; do
+    [[ "$k" == "encrypted" ]] && ENCRYPTED_HITS=$((ENCRYPTED_HITS + 1))
+done
+
+# Per-image overhead fit (any single image's overhead+headroom must fit)
+PER_IMG_NEED=$(( PER_IMAGE_OVERHEAD + (PER_IMAGE_OVERHEAD * HEADROOM_PCT / 100) ))
+PER_IMG_OVERSIZED=0
+if [[ "$IMG_COUNT" -gt 0 && "$PER_IMG_NEED" -gt "$FREE_BYTES" ]]; then
+    PER_IMG_OVERSIZED=1
+fi
+
+# ---- 4. choose mode ----
+MODE=""
+if [[ "$IMG_COUNT" -eq 0 ]]; then
+    MODE="bulk"
+elif [[ "$ENCRYPTED_HITS" -gt 0 || "$PER_IMG_OVERSIZED" -eq 1 ]]; then
+    MODE="blocked"
+elif [[ "$NEED_BYTES" -le "$FREE_BYTES" ]]; then
+    MODE="bulk"
+else
+    MODE="sequential"
+fi
+
+# ---- 5. write the plan file ----
+UTC_NOW="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+
+{
+    cat <<EOF
+# Disk-Image Mount Plan
+
+| Field | Value |
+|---|---|
+| Generated | ${UTC_NOW} |
+| Mode | ${MODE} |
+| Disk-image count | ${IMG_COUNT} |
+| Mount overhead per image | $(hsize "$PER_IMAGE_OVERHEAD") |
+| Total overhead | $(hsize "$TOTAL_OVERHEAD") |
+| Headroom (${HEADROOM_PCT}%) | $(hsize "$HEADROOM_BYTES") |
+| Required (overhead + headroom) | $(hsize "$NEED_BYTES") |
+| Free at \`${WORKING_DIR}\` | $(hsize "$FREE_BYTES") |
+
+> **Mount layer.** Disk images route through \`qemu-nbd\` (and \`ewfmount\` for
+> E01) into \`./working/mounts/<EV>/p<M>/\`, exposed read-only. Mounts consume
+> ~0 disk (block-device facade); planner sizes only mount-metadata + audit
+> overhead per image. Tool flow per DISCIPLINE §P-diskimage.
+
+EOF
+
+    if [[ "$IMG_COUNT" -gt 0 ]]; then
+        cat <<'EOF'
+| stage | source | format | logical-size | adapter chain |
+|---|---|---|---|---|
+EOF
+        for ((i=0; i<IMG_COUNT; i++)); do
+            stage="$((i + 1))"
+            [[ "$MODE" == "blocked" ]] && stage="-"
+            [[ "$MODE" == "bulk" ]] && stage="1"
+            printf '| %s | %s | %s | %s | %s |\n' \
+                "$stage" \
+                "${IMG_RELPATH[$i]}" \
+                "${IMG_KIND[$i]}" \
+                "$(hsize "${IMG_LOGICAL[$i]}")" \
+                "${IMG_ADAPTER[$i]}"
+        done
+    else
+        printf '\n_No disk images found in `%s` or `%s`._\n' \
+            "$EVIDENCE_DIR" "$WORKING_DIR"
+    fi
+
+    case "$MODE" in
+        bulk)
+            cat <<EOF
+
+## Plan: bulk
+
+Every disk image is mounted in Phase 1 (triage). Mounts persist for the
+duration of analysis and are detached at case close by
+\`diskimage-unmount-all.sh\` (QA-phase gate).
+
+Triage invokes \`diskimage-mount.sh <relpath> <EV>\` for each image in
+the order above.
+EOF
+            ;;
+        sequential)
+            cat <<EOF
+
+## Plan: sequential
+
+Combined mount overhead exceeds free space, but every image's overhead
+fits alone. Triage mounts the first image only; the orchestrator drives
+mount/dismount cycles per image. \`extraction-cleanup.sh\` calls
+\`diskimage-unmount.sh <EV>\` BEFORE deleting any \`./working/<bundle>/\`
+that contains the image source.
+EOF
+            ;;
+        blocked)
+            DEFICIT=0
+            if [[ "$PER_IMG_NEED" -gt "$FREE_BYTES" ]]; then
+                DEFICIT=$(( PER_IMG_NEED - FREE_BYTES ))
+            fi
+            cat <<EOF
+
+## Plan: blocked
+
+Triage MUST NOT mount any disk image. The orchestrator surfaces lead
+\`L-MOUNT-DISK-NN\` to the operator.
+
+| Field | Value |
+|---|---|
+| Encrypted images detected | ${ENCRYPTED_HITS} |
+| Per-image required (overhead + ${HEADROOM_PCT}% headroom) | $(hsize "$PER_IMG_NEED") |
+| Free at \`${WORKING_DIR}\` | $(hsize "$FREE_BYTES") |
+| Required-free-space delta | $(hsize "$DEFICIT") |
+
+Resolution paths:
+1. Provide a key for any encrypted source (re-run plan).
+2. Free enough disk to satisfy the delta; re-run \`diskimage-plan.sh\`.
+3. Mount a larger volume at \`./working/\` and re-run.
+EOF
+            ;;
+    esac
+} > "$PLAN_FILE"
+
+# ---- 6. on blocked, append BLOCKED leads to leads.md ----
+if [[ "$MODE" == "blocked" ]]; then
+    if [[ "$ENCRYPTED_HITS" -gt 0 ]]; then
+        for ((i=0; i<IMG_COUNT; i++)); do
+            [[ "${IMG_KIND[$i]}" == "encrypted" ]] || continue
+            hyp="Encrypted disk image: ${IMG_RELPATH[$i]} (qemu-img reports encrypted=yes); cannot mount without key"
+            notes="suggested-fix=provide-key; tool-needed=disk-decryption-key; re-run diskimage-plan.sh after key supplied"
+            lid="$(append_blocked_lead "L-MOUNT-DISK" "-" "$hyp" "analysis/diskimage-plan.md" "$notes")"
+            [[ -n "$lid" ]] || true
+        done
+    fi
+    if [[ "$PER_IMG_OVERSIZED" -eq 1 ]]; then
+        DEFICIT=$(( PER_IMG_NEED - FREE_BYTES ))
+        hyp="Disk-pressure block: per-image mount overhead $(hsize "$PER_IMG_NEED") exceeds free $(hsize "$FREE_BYTES")"
+        notes="required-free-space-delta=$(hsize "$DEFICIT"); free disk or remount before retrying"
+        lid="$(append_blocked_lead "L-MOUNT-DISK" "-" "$hyp" "analysis/diskimage-plan.md" "$notes")"
+        [[ -n "$lid" ]] || true
+    fi
+fi
+
+# ---- 7. audit + return ----
+if [[ -x "$AUDIT_SH" ]]; then
+    bash "$AUDIT_SH" "diskimage-plan computed" \
+        "cmd: bash diskimage-plan.sh; exit=0; mode=${MODE} images=${IMG_COUNT} encrypted=${ENCRYPTED_HITS} overhead=${TOTAL_OVERHEAD} free=${FREE_BYTES}" \
+        "diskimage-mount.sh per image per plan order" >/dev/null 2>&1 || true
+fi
+
+echo "diskimage-plan: mode=${MODE} images=${IMG_COUNT} encrypted=${ENCRYPTED_HITS} overhead=${TOTAL_OVERHEAD} free=${FREE_BYTES} plan=${PLAN_FILE}"
+
+case "$MODE" in
+    bulk|sequential) exit 0 ;;
+    blocked)         exit 1 ;;
+    *)               exit 2 ;;
+esac

--- a/.claude/skills/dfir-bootstrap/diskimage-unmount-all.sh
+++ b/.claude/skills/dfir-bootstrap/diskimage-unmount-all.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# diskimage-unmount-all.sh -- detach every disk-image mount in this case.
+#
+# Usage: bash diskimage-unmount-all.sh
+#
+# Walks ./working/mounts/.*.mount.json sentinels and invokes
+# diskimage-unmount.sh on each EV with "mounted": true. Used by:
+#
+#   - QA phase, immediately before case-close sign-off.
+#   - operator manual invocation when wrapping up a case.
+#
+# Exits 0 on full success, 1 if any per-EV unmount returned nonzero.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+AUDIT_SH="${SCRIPT_DIR}/audit.sh"
+UNMOUNT_SH="${SCRIPT_DIR}/diskimage-unmount.sh"
+
+if [[ ! -x "$UNMOUNT_SH" ]]; then
+    echo "diskimage-unmount-all: $UNMOUNT_SH not executable" >&2
+    exit 2
+fi
+
+MOUNTS_DIR="./working/mounts"
+if [[ ! -d "$MOUNTS_DIR" ]]; then
+    echo "diskimage-unmount-all: no $MOUNTS_DIR — nothing to do"
+    exit 0
+fi
+
+failures=0
+checked=0
+unmounted=0
+
+# Walk sentinel files. Pattern: ./working/mounts/.<EV>.mount.json
+shopt -s nullglob
+for sentinel in "${MOUNTS_DIR}"/.*.mount.json; do
+    [[ -f "$sentinel" ]] || continue
+    checked=$((checked + 1))
+
+    base="$(basename "$sentinel")"
+    # .EV01.mount.json -> EV01
+    ev="${base#.}"
+    ev="${ev%.mount.json}"
+
+    if [[ ! "$ev" =~ ^EV[0-9]{2,}$ ]]; then
+        echo "diskimage-unmount-all: skipping malformed sentinel $sentinel (ev=$ev)" >&2
+        continue
+    fi
+
+    if bash "$UNMOUNT_SH" "$ev"; then
+        unmounted=$((unmounted + 1))
+    else
+        failures=$((failures + 1))
+    fi
+done
+
+if [[ -x "$AUDIT_SH" ]]; then
+    bash "$AUDIT_SH" "diskimage-unmount-all: sweep" \
+        "cmd: bash diskimage-unmount-all.sh; exit=${failures}; checked=${checked} unmounted=${unmounted} failures=${failures}" \
+        "case-close OK" >/dev/null 2>&1 || true
+fi
+
+echo "diskimage-unmount-all: checked=${checked} unmounted=${unmounted} failures=${failures}"
+[[ "$failures" -eq 0 ]]

--- a/.claude/skills/dfir-bootstrap/diskimage-unmount.sh
+++ b/.claude/skills/dfir-bootstrap/diskimage-unmount.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# diskimage-unmount.sh -- canonical disk-image dismount per
+# DISCIPLINE §P-diskimage.
+#
+# Usage: bash diskimage-unmount.sh <ev-id>
+#
+# Reads ./working/mounts/.<ev>.mount.json (the sentinel written by
+# diskimage-mount.sh) and reverses the adapter chain:
+#
+#   1. umount each ./working/mounts/<EV>/p<M>/ partition
+#   2. qemu-nbd --disconnect /dev/nbd<N>
+#   3. fusermount -u <ewfmount-dir>     # E01 only
+#
+# Marks the sentinel as `unmounted` (does NOT delete -- chain-of-custody
+# record is preserved). Idempotent: re-running on an already-unmounted
+# sentinel is a no-op (logged once).
+#
+# Used by:
+#   - extraction-cleanup.sh (sequential mode, before rm -rf bundle dir)
+#   - diskimage-unmount-all.sh (case close, QA-phase gate)
+#   - operator manual invocation
+#
+# Every command emits an exact-command audit row per DISCIPLINE §A.1.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+AUDIT_SH="${SCRIPT_DIR}/audit.sh"
+
+EV_ID="${1:-}"
+if [[ -z "$EV_ID" ]]; then
+    echo "usage: diskimage-unmount.sh <ev-id>" >&2
+    exit 2
+fi
+if [[ ! "$EV_ID" =~ ^EV[0-9]{2,}$ ]]; then
+    echo "diskimage-unmount: ev-id must match EV[0-9]{2,} (got: $EV_ID)" >&2
+    exit 2
+fi
+
+SENTINEL="./working/mounts/.${EV_ID}.mount.json"
+if [[ ! -f "$SENTINEL" ]]; then
+    echo "diskimage-unmount: no sentinel for $EV_ID at $SENTINEL — nothing to do" >&2
+    exit 0
+fi
+
+emit_audit() {
+    local phase="$1" cmd="$2" rc="$3" extras="$4" nxt="$5"
+    local result="cmd: ${cmd}; exit=${rc}"
+    [[ -n "$extras" ]] && result+="; ${extras}"
+    if [[ -x "$AUDIT_SH" ]]; then
+        bash "$AUDIT_SH" "$phase" "$result" "$nxt" >/dev/null 2>&1 || true
+    fi
+}
+
+# Read sentinel fields with cheap awk/grep (avoid jq dependency).
+read_sentinel_field() {
+    local key="$1"
+    grep -oE "\"${key}\":[[:space:]]*\"[^\"]*\"" "$SENTINEL" 2>/dev/null \
+        | head -1 \
+        | sed -E "s/.*\"${key}\":[[:space:]]*\"([^\"]*)\".*/\1/"
+}
+
+read_sentinel_mounts() {
+    # Extract the mount_points array. Format: "mount_points": ["a", "b"]
+    grep -oE '"mount_points":[[:space:]]*\[[^]]*\]' "$SENTINEL" 2>/dev/null \
+        | head -1 \
+        | grep -oE '"[^"]+"' \
+        | tr -d '"'
+}
+
+read_sentinel_bool() {
+    local key="$1"
+    grep -oE "\"${key}\":[[:space:]]*(true|false)" "$SENTINEL" 2>/dev/null \
+        | head -1 \
+        | awk -F': *' '{print $2}'
+}
+
+NBD_DEV="$(read_sentinel_field nbd_device)"
+EWF_DIR="$(read_sentinel_field ewfmount_dir)"
+ALREADY_UNMOUNTED="$(read_sentinel_bool mounted)"
+
+# Idempotent: if sentinel says mounted=false, just confirm and exit.
+if [[ "$ALREADY_UNMOUNTED" == "false" ]]; then
+    emit_audit "diskimage-unmount: idempotent-skip" \
+        "sentinel ${SENTINEL} mounted=false" "0" "ev=${EV_ID}" "no-op"
+    echo "diskimage-unmount: $EV_ID already unmounted"
+    exit 0
+fi
+
+# 1. Unmount partitions (read from sentinel).
+for mp in $(read_sentinel_mounts); do
+    if mountpoint -q "$mp" 2>/dev/null; then
+        cmd="umount ${mp}"
+        sudo umount "$mp" 2>/dev/null
+        rc=$?
+        emit_audit "diskimage-unmount: umount" "$cmd" "$rc" "mountpoint=${mp}" \
+            "next partition or qemu-nbd --disconnect"
+    fi
+done
+
+# 2. qemu-nbd --disconnect
+if [[ -n "$NBD_DEV" && -b "$NBD_DEV" ]]; then
+    cmd="qemu-nbd --disconnect ${NBD_DEV}"
+    sudo qemu-nbd --disconnect "$NBD_DEV" 2>/dev/null
+    rc=$?
+    emit_audit "diskimage-unmount: nbd-detach" "$cmd" "$rc" "nbd=${NBD_DEV}" \
+        "fusermount -u (E01 only) or done"
+fi
+
+# 3. fusermount -u (ewfmount layer, E01 only)
+if [[ -n "$EWF_DIR" && -d "$EWF_DIR" ]]; then
+    if mountpoint -q "$EWF_DIR" 2>/dev/null; then
+        cmd="fusermount -u ${EWF_DIR}"
+        fusermount -u "$EWF_DIR" 2>/dev/null
+        rc=$?
+        emit_audit "diskimage-unmount: ewfmount-detach" "$cmd" "$rc" \
+            "ewfdir=${EWF_DIR}" "mark sentinel unmounted"
+    fi
+fi
+
+# 4. Mark sentinel unmounted (preserve chain-of-custody record).
+UTC_NOW="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+# In-place edit: flip "mounted": true -> false; set ts_detach.
+# sed -i is denied on audit log paths but allowed on sentinels in working/mounts/.
+sed -i.bak \
+    -e "s/\"mounted\":[[:space:]]*true/\"mounted\": false/" \
+    -e "s/\"ts_detach\":[[:space:]]*null/\"ts_detach\": \"${UTC_NOW}\"/" \
+    "$SENTINEL" 2>/dev/null
+rm -f "${SENTINEL}.bak" 2>/dev/null
+
+emit_audit "diskimage-unmount: sentinel-mark" \
+    "sed -i mounted=false ts_detach=${UTC_NOW} ${SENTINEL}" "0" \
+    "ev=${EV_ID}" "done"
+
+echo "diskimage-unmount: $EV_ID detached"
+exit 0

--- a/.claude/skills/dfir-bootstrap/extraction-cleanup.sh
+++ b/.claude/skills/dfir-bootstrap/extraction-cleanup.sh
@@ -82,6 +82,44 @@ if [[ "$real_target" != "$real_extract"/* ]]; then
     exit 1
 fi
 
+# ---------- pre-cleanup: dismount any disk-image mounts under TARGET ----------
+# Disk images discovered nested inside ./working/<bundle>/ may have been
+# mounted via diskimage-mount.sh, leaving /dev/nbd<N> attached and
+# ./working/mounts/<EV>/p<M>/ mounted. We MUST detach those before rm -rf,
+# or the kernel will refuse the unlink. Walk all sentinels, find any whose
+# source_relpath resolves under TARGET, and call diskimage-unmount.sh.
+UNMOUNT_SH="${SCRIPT_DIR}/diskimage-unmount.sh"
+unmount_failures=0
+shopt -s nullglob
+for sentinel in ./working/mounts/.*.mount.json; do
+    [[ -f "$sentinel" ]] || continue
+    src_rel="$(grep -oE '"source_relpath":[[:space:]]*"[^"]+"' "$sentinel" 2>/dev/null \
+               | head -1 | sed -E 's/.*"source_relpath":[[:space:]]*"([^"]+)".*/\1/')"
+    [[ -z "$src_rel" ]] && continue
+    # Source is under TARGET if it starts with the bundle-relative prefix.
+    case "$src_rel" in
+        "working/${BASENAME}/"*|"./working/${BASENAME}/"*)
+            base="$(basename "$sentinel")"
+            ev="${base#.}"; ev="${ev%.mount.json}"
+            if [[ "$ev" =~ ^EV[0-9]{2,}$ ]]; then
+                if ! bash "$UNMOUNT_SH" "$ev"; then
+                    unmount_failures=$((unmount_failures + 1))
+                    echo "extraction-cleanup: WARN -- diskimage-unmount.sh $ev failed" >&2
+                fi
+            fi
+            ;;
+    esac
+done
+if [[ "$unmount_failures" -gt 0 ]]; then
+    if [[ -x "$AUDIT_SH" ]]; then
+        bash "$AUDIT_SH" "extraction-cleanup REFUSED" \
+            "${unmount_failures} disk-image mount(s) under ${TARGET} failed to detach" \
+            "operator: investigate orphan /dev/nbd<N>; rerun cleanup after manual unmount" >/dev/null 2>&1 || true
+    fi
+    echo "extraction-cleanup: REFUSED -- ${unmount_failures} mount(s) under ${TARGET} could not be detached; aborting rm -rf" >&2
+    exit 1
+fi
+
 # Count files (depth-unbounded, regular files only) before deletion. This
 # is the "deleted=<N>" figure the audit line carries.
 DELETED_COUNT="$(find "$TARGET" -type f 2>/dev/null | wc -l | tr -d '[:space:]')"

--- a/.claude/skills/dfir-bootstrap/install-tools.sh
+++ b/.claude/skills/dfir-bootstrap/install-tools.sh
@@ -71,6 +71,8 @@ BASE_APT_REQUIRED=(
     sleuthkit
     libewf            # modern libewf shared lib (used by sleuthkit, plaso, etc.)
     libewf-tools      # ewfinfo / ewfverify / ewfmount / ewfacquire / ewfexport
+    qemu-utils        # qemu-nbd + qemu-img — disk-image read-only mount adapter (DISCIPLINE §P-diskimage)
+    fuse              # ewfmount FUSE backend
     testdisk
     hashdeep
     yara

--- a/.claude/skills/dfir-bootstrap/manifest-check.sh
+++ b/.claude/skills/dfir-bootstrap/manifest-check.sh
@@ -278,6 +278,78 @@ for w in walked:
             "fix":      f"bundle {ev_id} has {len(member_rows)} member rows but {on_disk_count} files on disk under {dest}; partial expansion — operator clears {dest} and re-runs case-init.sh",
         })
 
+# ---- 3.5 disk-mount rows must have a parent blob row + non-empty hashes ----
+# Every disk-image mount writes a manifest row keyed `<EV>-MOUNT` of
+# type=disk-mount, with parent=<EV>. The parent row must exist (the
+# original-evidence blob) AND both rows must carry non-empty sha256.
+# When the sentinel says mounted=true, /dev/nbd<N> must still be a
+# block device (kernel-attached). Failures appear as L-MOUNT-LEDGER-NN.
+mount_rows = [r for r in rows if r["type"] == "disk-mount"]
+mount_violations = []
+
+import glob
+sentinel_by_ev = {}
+for s in glob.glob("./working/mounts/.*.mount.json"):
+    bn = os.path.basename(s)
+    ev = bn[1:].rsplit(".mount.json", 1)[0]
+    if re.match(r"^EV[0-9]{2,}$", ev):
+        try:
+            sentinel_by_ev[ev] = json.load(open(s, "r", encoding="utf-8"))
+        except Exception:
+            sentinel_by_ev[ev] = None
+
+for r in mount_rows:
+    ev = r["ev_id"]
+    parent = r["parent"]
+    # ev_id format is "<PARENT>-MOUNT"; parent column should be the parent EV id
+    if not ev.endswith("-MOUNT"):
+        mount_violations.append({
+            "kind":  "disk-mount-id-malformed",
+            "path":  r["path"],
+            "ev_id": ev,
+            "fix":   f"disk-mount row {ev} should be keyed '<PARENT-EV>-MOUNT'; re-run case-init.sh after correcting the row",
+        })
+        continue
+    expected_parent = ev[:-len("-MOUNT")]
+    if parent != expected_parent:
+        mount_violations.append({
+            "kind":  "disk-mount-parent-mismatch",
+            "ev_id": ev,
+            "fix":   f"disk-mount row {ev} declares parent='{parent}' but ev_id implies parent='{expected_parent}'; re-run case-init.sh after correcting the row",
+        })
+    parent_row = by_ev.get(expected_parent)
+    if not parent_row:
+        mount_violations.append({
+            "kind":  "disk-mount-parent-missing",
+            "ev_id": ev,
+            "fix":   f"disk-mount row {ev} has no parent blob row {expected_parent}; chain-of-custody broken — re-run case-init.sh on the source evidence",
+        })
+        continue
+    if not parent_row["sha256"] or parent_row["sha256"].strip() == "-":
+        mount_violations.append({
+            "kind":  "disk-mount-parent-unhashed",
+            "ev_id": ev,
+            "fix":   f"disk-mount row {ev} parent {expected_parent} has empty sha256 — original-artifact hashing failed; re-run case-init.sh",
+        })
+    if not r["sha256"] or r["sha256"].strip() == "-":
+        mount_violations.append({
+            "kind":  "disk-mount-unhashed",
+            "ev_id": ev,
+            "fix":   f"disk-mount row {ev} has empty sha256 — /dev/nbd<N> stream hash missing; re-run diskimage-mount.sh on the source",
+        })
+    # If sentinel says mounted=true, the /dev/nbdN block device should exist.
+    sent = sentinel_by_ev.get(expected_parent)
+    if sent and sent.get("mounted") is True:
+        nbd_dev = sent.get("nbd_device") or ""
+        if nbd_dev and not os.path.exists(nbd_dev):
+            mount_violations.append({
+                "kind":  "disk-mount-nbd-detached",
+                "ev_id": ev,
+                "fix":   f"sentinel for {expected_parent} declares mounted=true but {nbd_dev} is no longer attached; either re-run diskimage-mount.sh or call diskimage-unmount.sh to clear the sentinel",
+            })
+
+violations.extend(mount_violations)
+
 # ---- 4. sha256 = '-' must be paired with a documented bundle-skipped reason ----
 # Read leads.md (if present); look for an L-EXTRACT-* row that names the
 # offending ev_id and includes the literal token "operator-acknowledged".
@@ -377,6 +449,31 @@ if bespoke_violations:
             lid = next_lead_id(leads_path, "L-MANIFEST-BESPOKE")
             notes = "operator must reconcile rows into manifest.md before removing the bespoke file (it may carry forensic work that needs migration, not deletion)"
             fh.write(f"| {lid} | - | bootstrap | {hyp} | {v['path']} | high | blocked | {notes} |\n")
+            v["lead_id"] = lid
+
+# Mount-ledger violations get their own BLOCKED leads keyed L-MOUNT-LEDGER-NN.
+mount_ledger_kinds = {
+    "disk-mount-id-malformed",
+    "disk-mount-parent-mismatch",
+    "disk-mount-parent-missing",
+    "disk-mount-parent-unhashed",
+    "disk-mount-unhashed",
+    "disk-mount-nbd-detached",
+}
+mount_ledger_violations = [v for v in violations if v["kind"] in mount_ledger_kinds]
+if mount_ledger_violations:
+    ensure_leads_md(leads_path)
+    with open(leads_path, "r", encoding="utf-8") as fh:
+        existing = fh.read()
+    with open(leads_path, "a", encoding="utf-8") as fh:
+        for v in mount_ledger_violations:
+            ev = v.get("ev_id", "-")
+            hyp = f"Mount ledger violation ({v['kind']}) on {ev}: {v.get('fix', '')[:160]}"
+            if hyp in existing:
+                continue
+            lid = next_lead_id(leads_path, "L-MOUNT-LEDGER")
+            notes = v.get("fix", "operator: review manifest.md disk-mount rows and ./working/mounts/ sentinels")
+            fh.write(f"| {lid} | {ev} | bootstrap | {hyp} | analysis/manifest.md | high | blocked | {notes} |\n")
             v["lead_id"] = lid
 
 # ---- 7. emit + audit ----

--- a/.claude/skills/dfir-bootstrap/preflight.sh
+++ b/.claude/skills/dfir-bootstrap/preflight.sh
@@ -109,6 +109,12 @@ bin_check img_stat || true
 bin_check ewfinfo || true
 bin_check ewfverify || true
 bin_check ewfmount || true
+bin_check ewfacquire || true
+bin_check qemu-nbd || true
+bin_check qemu-img || true
+bin_check fusermount || true
+bin_check mount || true
+bin_check umount || true
 bin_check log2timeline.py || true
 bin_check psort.py || true
 bin_check pinfo.py || true
@@ -400,6 +406,25 @@ else
     printf "| sleuthkit | RED | missing fls/mactime/libewf — install \`sleuthkit\` + \`libewf\` (or \`libewf2\`) |\n"
 fi
 
+# disk-image-mount — needs qemu-nbd + qemu-img (always) AND ewfmount (E01 sources only)
+# Probe nbd kernel module for informational purposes; mount script loads it on demand.
+NBD_NOTE=""
+if lsmod 2>/dev/null | grep -q '^nbd'; then
+    NBD_NOTE="nbd module loaded"
+elif modinfo nbd >/dev/null 2>&1; then
+    NBD_NOTE="nbd module installed (load on demand)"
+else
+    NBD_NOTE="nbd module absent — kernel may not support qemu-nbd"
+fi
+if command -v qemu-nbd >/dev/null 2>&1 && command -v qemu-img >/dev/null 2>&1 \
+   && command -v ewfmount >/dev/null 2>&1; then
+    printf "| disk-image-mount | GREEN | qemu-nbd + qemu-img + ewfmount present; %s |\n" "$NBD_NOTE"
+elif command -v qemu-nbd >/dev/null 2>&1 && command -v qemu-img >/dev/null 2>&1; then
+    printf "| disk-image-mount | YELLOW | qemu-nbd + qemu-img present, ewfmount missing — E01 sources BLOCK; install \`libewf-tools\`; %s |\n" "$NBD_NOTE"
+else
+    printf "| disk-image-mount | RED | qemu-nbd / qemu-img missing — install \`qemu-utils\`; %s |\n" "$NBD_NOTE"
+fi
+
 # plaso-timeline
 if command -v log2timeline.py >/dev/null 2>&1; then
     printf "| plaso-timeline | GREEN | log2timeline.py on PATH |\n"
@@ -491,6 +516,16 @@ if command -v fls >/dev/null 2>&1 && command -v mactime >/dev/null 2>&1 \
     printf "SKILL_STATUS:sleuthkit=GREEN\n"
 else
     printf "SKILL_STATUS:sleuthkit=RED\n"
+fi
+
+# disk-image-mount
+if command -v qemu-nbd >/dev/null 2>&1 && command -v qemu-img >/dev/null 2>&1 \
+   && command -v ewfmount >/dev/null 2>&1; then
+    printf "SKILL_STATUS:disk-image-mount=GREEN\n"
+elif command -v qemu-nbd >/dev/null 2>&1 && command -v qemu-img >/dev/null 2>&1; then
+    printf "SKILL_STATUS:disk-image-mount=YELLOW\n"
+else
+    printf "SKILL_STATUS:disk-image-mount=RED\n"
 fi
 
 # plaso-timeline

--- a/.claude/skills/dfir-bootstrap/refactor-verify.sh
+++ b/.claude/skills/dfir-bootstrap/refactor-verify.sh
@@ -22,13 +22,13 @@ emit() { printf '%-70s %s\n' "$1" "$2"; }
 # ---- 1. Discipline marker ----
 SELF="$(basename "$0")"
 markers=$(grep -rn "discipline_v" .claude/ CLAUDE.md ARCHITECTURE.md README.md VALIDATION.md 2>/dev/null \
-          | grep -v "$SELF" | grep -c "discipline_v3_loaded" || true)
-v1_remaining=$(grep -rn "discipline_v1_loaded" .claude/ CLAUDE.md ARCHITECTURE.md README.md VALIDATION.md 2>/dev/null \
+          | grep -v "$SELF" | grep -c "discipline_v4_loaded" || true)
+older_remaining=$(grep -rnE "discipline_v[0-3]_loaded" .claude/ CLAUDE.md ARCHITECTURE.md README.md VALIDATION.md 2>/dev/null \
                | grep -v "$SELF" | wc -l)
-if [[ "$markers" -gt 0 && "$v1_remaining" -eq 0 ]]; then
-    emit "1. discipline marker (v2 only, $markers ref)" "PASS"
+if [[ "$markers" -gt 0 && "$older_remaining" -eq 0 ]]; then
+    emit "1. discipline marker (v4 only, $markers ref)" "PASS"
 else
-    emit "1. discipline marker (v2=$markers v1=$v1_remaining)" "FAIL"
+    emit "1. discipline marker (v4=$markers older=$older_remaining)" "FAIL"
     fails=$((fails+1))
 fi
 
@@ -104,6 +104,44 @@ if [[ "$policies" -eq 5 ]]; then
     emit "8. DISCIPLINE.md policy rules (5 / 5)" "PASS"
 else
     emit "8. DISCIPLINE.md policy rules ($policies / 5)" "FAIL"
+    fails=$((fails+1))
+fi
+
+# ---- 8b. v4 disk-image residue scan ----
+# After the mount-don't-convert refactor, the strings working/e01 and
+# conversion-e01 should not appear in any agent prompt, skill file, or
+# CLAUDE.md / ARCHITECTURE.md. ewfacquire is still installed (libewf-tools
+# bundles it) but should not be invoked from any prompt.
+e01_residue=$(grep -rnE 'working/e01|conversion-e01' \
+              .claude/agents/ .claude/skills/ CLAUDE.md ARCHITECTURE.md 2>/dev/null \
+              | grep -v "$SELF" | wc -l)
+if [[ "$e01_residue" -eq 0 ]]; then
+    emit "8b. v4 disk-image residue (0 working/e01|conversion-e01 hits)" "PASS"
+else
+    emit "8b. v4 disk-image residue ($e01_residue hits)" "FAIL"
+    grep -rnE 'working/e01|conversion-e01' \
+        .claude/agents/ .claude/skills/ CLAUDE.md ARCHITECTURE.md 2>/dev/null \
+        | grep -v "$SELF" | head -5 >&2
+    fails=$((fails+1))
+fi
+
+# ---- 8c. v4 mount helpers present + executable ----
+mount_helpers=(
+    .claude/skills/dfir-bootstrap/diskimage-plan.sh
+    .claude/skills/dfir-bootstrap/diskimage-mount.sh
+    .claude/skills/dfir-bootstrap/diskimage-unmount.sh
+    .claude/skills/dfir-bootstrap/diskimage-unmount-all.sh
+)
+helpers_ok=0
+for h in "${mount_helpers[@]}"; do
+    if [[ -x "$h" ]]; then
+        helpers_ok=$((helpers_ok+1))
+    fi
+done
+if [[ "$helpers_ok" -eq "${#mount_helpers[@]}" ]]; then
+    emit "8c. v4 mount helpers ($helpers_ok / ${#mount_helpers[@]} executable)" "PASS"
+else
+    emit "8c. v4 mount helpers ($helpers_ok / ${#mount_helpers[@]} executable)" "FAIL"
     fails=$((fails+1))
 fi
 

--- a/.claude/skills/dfir-discipline/DISCIPLINE.md
+++ b/.claude/skills/dfir-discipline/DISCIPLINE.md
@@ -19,12 +19,12 @@ These rules apply at every step of every phase agent (`dfir-triage`,
 
   Examples:
 
-    2026-05-02 14:12:33 UTC | dfir-triage start | discipline_v3_loaded; 4 evidence items EV01..EV04 | dispatch surveyors per ORCHESTRATE Phase 2
+    2026-05-02 14:12:33 UTC | dfir-triage start | discipline_v4_loaded; 4 evidence items EV01..EV04 | dispatch surveyors per ORCHESTRATE Phase 2
     2026-05-02 14:18:07 UTC | fls -r -o 65664 EV01.E01 | 11553 entries; NTFS at offset 65664 | feed mactime; pivot logon timestamps in survey-EV01.md
 </audit-log-format>
 
 <marker-self-attestation>
-  Every agent invocation emits the literal marker `discipline_v3_loaded` in
+  Every agent invocation emits the literal marker `discipline_v4_loaded` in
   the `result` field of its first audit row. The orchestrator and dfir-qa
   grep for it. A missing marker is a self-attestation failure recorded by
   dfir-qa as `INTEGRITY-VIOLATION: missing discipline marker`.
@@ -80,7 +80,7 @@ wall-clock) times will not survive cross-examination.
 
 **How to apply:**
 - The first audit-log entry of every agent invocation MUST include
-  `discipline_v3_loaded` somewhere in the `result` field. The orchestrator
+  `discipline_v4_loaded` somewhere in the `result` field. The orchestrator
   will grep for this marker.
 - Never `echo "<UTC>" >> ./analysis/forensic_audit.log` or
   `tee -a ./analysis/forensic_audit.log`. The PreToolUse hook denies
@@ -102,7 +102,7 @@ deterministically without consulting the project README.
 | # | Layer | Path | Origin | Mutability | Integrity ledger | Hook |
 |---|-------|------|--------|------------|------------------|------|
 | 1 | Original evidence | `./evidence/` | Operator drop at intake | Read-only after intake (`chmod a-w` recursive) | `analysis/manifest.md` | Permission deny + filesystem lock |
-| 2 | Bundle expansion | `./working/<bundle>/` | `case-init.sh` expanding archives at intake | Read-only by convention | `analysis/manifest.md` (`bundle-member` rows) | None — manifest-locked at write-once intake |
+| 2 | Bundle expansion + disk-image mounts | `./working/<bundle>/`, `./working/mounts/<EV>/p<M>/` | `case-init.sh` expanding archives + `diskimage-mount.sh` exposing read-only mounts | Read-only by convention; mounts read-only by kernel | `analysis/manifest.md` (`bundle-member`, `disk-mount` rows) | None — manifest-locked at write-once intake; mounts detached at case close |
 | 3 | Tool reports | `./analysis/<domain>/` | Surveyor + investigator output (CSVs, JSON, `findings.md`, `survey-EVnn.md`) | Mutable (recomputable) | None — by design | audit-log hooks only |
 | 4 | Derived artifacts | `./exports/<domain>/...` | Carved bytes, exported hives, dumped memory regions, sliced pcaps, reassembled HTTP objects | Write-once; mutation = chain-of-custody concern | `analysis/exports-manifest.md` | `audit-exports.sh` PostToolUse, depth-unbounded |
 | 5 | Reports | `./reports/` | Final deliverables (`final.md`, `stakeholder-summary.md`, `qa-review.md`, `00_intake.md`) | Mutable | None | None |
@@ -576,46 +576,105 @@ itself emits a tree we don't control.
 
 ---
 
-<rule id="P-diskimage" binds="dfir-triage,dfir-surveyor">
-  <name>Non-E01 disk images are converted to E01 with hashes</name>
+<rule id="P-diskimage" binds="dfir-triage,dfir-surveyor,dfir-qa">
+  <name>Disk images are mounted read-only via qemu-nbd; never converted</name>
   <statement>
-    Every disk-image evidence item that is not already E01 is converted
-    to E01 with sha256 hashing, in `./working/e01/`, before any analysis
-    tool reads it. The conversion event is audited; the source hash and
-    the post-conversion E01 hash are both recorded in `./analysis/manifest.md`.
+    Every disk-image evidence item — E01, raw `.dd`/`.raw`/`.img`,
+    `.vmdk`, `.vhd`, `.vhdx`, `.qcow2` — is exposed read-only at
+    `/dev/nbd<N>` and mounted under `./working/mounts/<EV>/p<M>/` via
+    the canonical adapter chain below. Downstream tools operate off the
+    mount; no conversion to E01 is performed. The original artifact's
+    sha256 and the byte-stream sha256 of `/dev/nbd<N>` are both recorded
+    in `./analysis/manifest.md`. Mounts persist for the duration of
+    analysis and are detached at case close, or per stage when
+    sequential mode is active.
   </statement>
   <why>
-    E01 is the project's canonical disk-image envelope. It carries
-    embedded chain-of-custody metadata, per-segment integrity hashes,
-    and uniform support across every disk-domain tool (TSK, ewfmount,
-    Velociraptor). Mixed formats (raw `.dd`, `.vmdk`, `.vhd`, `.vhdx`,
-    split `.001`, `.ad1`) force per-tool handling and create
-    format-specific bug surface.
+    Conversion to E01 fails on virtual disks: `ewfacquire` reads
+    container bytes (descriptor + sparse extents) verbatim and produces
+    a malformed E01 that downstream tools reject as corrupt. Mounting
+    via `qemu-nbd` (and `ewfmount` for E01) collapses every format into
+    a single read-only block-device + filesystem-mount surface, so
+    downstream tools see the same shape regardless of source format.
+    Mounts are read-only, reversible, and consume ~0 disk — they remove
+    the conversion class of failures entirely.
   </why>
   <how>
-    - Conversion runs as part of triage's working-copy preparation.
-    - Source: `./evidence/<file>` (locked read-only by case-init).
-    - Destination: `./working/e01/<source-name>.E01`.
-    - Tooling: `ewfacquire` (libewf2). Compression: best. Hash: sha256.
-    - Manifest rows: one row for the source (`type=blob`), one row for
-      the converted E01 (`type=conversion-e01`, `parent=EV<NN>`,
-      `notes=ewfacquire compression=best hash=sha256`).
-    - When conversion fails (corrupt source, unsupported format,
-      `ewfacquire` missing), mark the originating lead BLOCKED per
-      Rule P-priority.
-    - E01 sources pass through unchanged.
+    Single source of truth for the adapter chain and the mandatory
+    audit-row sequence:
+
+    | Source                                   | Adapter chain                                                  |
+    |------------------------------------------|----------------------------------------------------------------|
+    | `.E01` (single or split segments)        | `ewfmount` → `qemu-nbd -f raw` → `mount -o ro,noload`          |
+    | `.dd` / `.raw` / `.img`                  | `qemu-nbd -f raw` → `mount -o ro,noload`                       |
+    | `.vmdk` (any subformat)                  | `qemu-nbd -f vmdk` → `mount -o ro,noload`                      |
+    | `.vhd` (fixed / dynamic)                 | `qemu-nbd -f vpc` → `mount -o ro,noload`                       |
+    | `.vhdx`                                  | `qemu-nbd -f vhdx` → `mount -o ro,noload`                      |
+    | `.qcow2`                                 | `qemu-nbd -f qcow2` → `mount -o ro,noload`                     |
+    | encrypted (any of above)                 | BLOCK before attach — `L-MOUNT-DISK-NN; suggested-fix=provide-key` |
+
+    Triage invokes the canonical helper:
+    `bash .claude/skills/dfir-bootstrap/diskimage-mount.sh <relpath> <EV>`.
+    The helper enforces: format detection → `modprobe nbd max_part=16`
+    if needed → adapter attach → `mmls /dev/nbd<N>` → partition mounts
+    → `sha256sum <source>` → `sha256sum /dev/nbd<N>` → sentinel write
+    → trap-driven detach on every exit path. Manifest rows: `type=blob`
+    for the source, `type=disk-mount` for the byte stream
+    (`parent=EV<NN>`, `notes=adapter=<chain>; mount-points=<list>; nbd-byte-sha256=<sha>`).
+    Detachment runs from `bash diskimage-unmount.sh <EV>` (sequential
+    cleanup) or `bash diskimage-unmount-all.sh` (case close, QA gate).
+
+    Every command run by the helper — and every command an analyst
+    runs against a mount or `/dev/nbd<N>` afterwards — is recorded as an
+    exact-command audit row per <rule ref="DISCIPLINE §A.1"/>. The row's
+    `result` field carries the literal command line, the exit code, and
+    any key=val pairs needed to reproduce the operation. No
+    paraphrasing, no abbreviation. Investigator review must be able to
+    replay the case from the audit log alone.
+
+    BLOCK conditions (mark the lead per <rule ref="DISCIPLINE §P-priority"/>):
+    - `qemu-nbd` missing → `suggested-fix=install-package; tool-needed=qemu-nbd`
+    - `ewfmount` missing on an E01 source → `suggested-fix=install-package; tool-needed=ewfmount`
+    - encrypted virtual disk → `suggested-fix=provide-key`
+    - filesystem driver missing (HFS+, APFS, ZFS) → `suggested-fix=install-driver; tool-needed=<fs-driver>`
+    - corrupt source / `qemu-nbd --connect` exits nonzero → `L-MOUNT-FAIL-NN`,
+      trap detaches, audit row records the failure command line and exit code.
   </how>
 </rule>
 
 <example for="P-diskimage">
   ```bash
-  # Convert .dd to E01:
-  ewfacquire \
-      -t ./working/e01/EV01 \
-      -c best -d sha256 -u -CCASEID -DDESC -EEXAM -eEVID -mremovable -Mlogical -nNOTES \
-      ./evidence/EV01.dd
-  # Resulting file: ./working/e01/EV01.E01
-  bash audit.sh "ewfacquire EV01.dd -> E01" "sha256-source=<src> sha256-e01=<dst>" "manifest append; surveyor reads from working/e01/EV01.E01"
+  # Bootstrap nbd kernel module (idempotent)
+  lsmod | grep -q '^nbd' || sudo modprobe nbd max_part=16
+  bash audit.sh "triage: modprobe-nbd" "cmd: modprobe nbd max_part=16; exit=0" "qemu-nbd attach"
+
+  # Detect format
+  qemu-img info ./evidence/EV01.vmdk
+  bash audit.sh "triage: detect-format" "cmd: qemu-img info ./evidence/EV01.vmdk; exit=0; format=vmdk virtual-size=64G" "qemu-nbd attach"
+
+  # Attach VMDK as /dev/nbd0 (read-only)
+  sudo qemu-nbd --read-only --cache=none --format=vmdk --connect=/dev/nbd0 ./evidence/EV01.vmdk
+  bash audit.sh "triage: nbd-attach" "cmd: qemu-nbd --read-only --cache=none --format=vmdk --connect=/dev/nbd0 ./evidence/EV01.vmdk; exit=0; nbd=/dev/nbd0" "mmls + mount partitions"
+
+  # Inspect partition table
+  mmls /dev/nbd0 | tee ./analysis/filesystem/mmls-EV01.txt
+  bash audit.sh "triage: mmls" "cmd: mmls /dev/nbd0; exit=0; partitions=2" "mount p1, p2"
+
+  # Mount each filesystem partition
+  mkdir -p ./working/mounts/EV01/p1
+  sudo mount -o ro,noload /dev/nbd0p1 ./working/mounts/EV01/p1
+  bash audit.sh "triage: partition-mount" "cmd: mount -o ro,noload /dev/nbd0p1 ./working/mounts/EV01/p1; exit=0; fs=ntfs" "hash mount-source"
+
+  # Hash original artifact + mount-source byte stream
+  sha256sum ./evidence/EV01.vmdk
+  sha256sum /dev/nbd0
+  bash audit.sh "triage: source-hash" "cmd: sha256sum ./evidence/EV01.vmdk; exit=0; sha=<src-sha>" "manifest blob row"
+  bash audit.sh "triage: nbd-stream-hash" "cmd: sha256sum /dev/nbd0; exit=0; sha=<nbd-sha>" "manifest disk-mount row"
+
+  # Detach (every exit path, via trap)
+  sudo umount ./working/mounts/EV01/p1
+  sudo qemu-nbd --disconnect /dev/nbd0
+  bash audit.sh "triage: nbd-detach" "cmd: qemu-nbd --disconnect /dev/nbd0; exit=0" "case-close: sentinel marked unmounted"
   ```
 </example>
 
@@ -785,10 +844,10 @@ itself emits a tree we don't control.
 
 <example for="P-yara">
   ```bash
-  # Disk image scan:
-  yara -r -s -p 4 /opt/yara-rules/malware/ ./working/e01/EV01.E01 \
+  # Disk image scan against the mounted filesystem tree:
+  yara -r -s -p 4 /opt/yara-rules/malware/ ./working/mounts/EV01/p1/ \
       > ./exports/yara_hits/yara-EV01.txt
-  bash audit.sh "yara -r /opt/yara-rules/malware EV01" "<hit count>" "review hits; pivot per matched rule"
+  bash audit.sh "yara: dir-scan" "cmd: yara -r -s -p 4 /opt/yara-rules/malware/ ./working/mounts/EV01/p1/; exit=0; hits=<n>" "review hits; pivot per matched rule"
   ```
 </example>
 
@@ -843,7 +902,7 @@ itself emits a tree we don't control.
 
 - The DISCIPLINE.md path is referenced from each agent's frontmatter as
   `MANDATORY` — the agent harness does not enforce reading; the marker
-  `discipline_v3_loaded` is the self-attestation signal.
+  `discipline_v4_loaded` is the self-attestation signal.
 - The PreToolUse / PostToolUse hooks enforce Rule A mechanically. Rules
   F / G / H / B are agent-prompt-level discipline; they are caught after
   the fact by audit-log review and by the orchestrator's correlation-

--- a/.claude/skills/dfir-discipline/SKILL.md
+++ b/.claude/skills/dfir-discipline/SKILL.md
@@ -8,7 +8,7 @@ agent's `<mandatory>` line points here.
 <contents>
 - [`DISCIPLINE.md`](./DISCIPLINE.md) — the rules. Defines:
   - `<audit-log-format>` — canonical row grammar
-  - `<marker-self-attestation>` — `discipline_v3_loaded` requirement
+  - `<marker-self-attestation>` — `discipline_v4_loaded` requirement
   - `<index>` — concept → section map
   - Rules A, B, F, G, H, I, J, K, L, P-pcap, P-diskimage, P-priority, P-yara, P-sigma
 - [`templates/survey-template.md`](./templates/survey-template.md) — Phase-2
@@ -21,6 +21,6 @@ agent's `<mandatory>` line points here.
 
 <usage>
 Every phase agent's first action: read `DISCIPLINE.md`, then emit the marker
-`discipline_v3_loaded` in the `result` field of its first audit row. The
+`discipline_v4_loaded` in the `result` field of its first audit row. The
 orchestrator and `dfir-qa` grep for it.
 </usage>

--- a/.claude/skills/dfir-discipline/templates/survey-template.md
+++ b/.claude/skills/dfir-discipline/templates/survey-template.md
@@ -42,7 +42,7 @@
 - **Evidence ID:** `<EV_ID>`           <!-- e.g. EV01 -->
 - **Evidence sha256:** `<sha256>`      <!-- copy from analysis/manifest.md -->
 - **Domain:** `<domain>`               <!-- one of: filesystem, timeline, windows-artifacts, memory, network, yara, sigma -->
-- **Surveyor agent version:** `dfir-surveyor / discipline_v3_loaded`
+- **Surveyor agent version:** `dfir-surveyor / discipline_v4_loaded`
 - **UTC timestamp:** `<YYYY-MM-DD HH:MM:SS UTC>`
 
 ## Tools run

--- a/.claude/skills/memory-analysis/reference/example-survey.md
+++ b/.claude/skills/memory-analysis/reference/example-survey.md
@@ -12,7 +12,7 @@
 - **Evidence ID:** EV03
 - **Evidence sha256:** a14d2e9b6c8f0712304a5b6c7d8e9f001112223344556677889900aabbccddee
 - **Domain:** memory
-- **Surveyor agent version:** dfir-surveyor / discipline_v3_loaded
+- **Surveyor agent version:** dfir-surveyor / discipline_v4_loaded
 - **UTC timestamp:** 2026-04-26 14:25:03 UTC
 
 ## Tools run

--- a/.claude/skills/network-forensics/reference/example-survey.md
+++ b/.claude/skills/network-forensics/reference/example-survey.md
@@ -12,7 +12,7 @@
 - **Evidence ID:** EV02
 - **Evidence sha256:** 3b27c81dffe204169c5b2d8a4e6f70819293847560abcdef0123456789abcdef
 - **Domain:** network
-- **Surveyor agent version:** dfir-surveyor / discipline_v3_loaded
+- **Surveyor agent version:** dfir-surveyor / discipline_v4_loaded
 - **UTC timestamp:** 2026-04-26 14:18:42 UTC
 
 ## Tools run

--- a/.claude/skills/plaso-timeline/SKILL.md
+++ b/.claude/skills/plaso-timeline/SKILL.md
@@ -1,5 +1,9 @@
 # Skill: Timeline Generation (Plaso / log2timeline)
 
+<disk-image-source>
+Disk images (E01, raw/dd, vmdk, vhd, vhdx, qcow2) are mounted read-only by triage via `diskimage-mount.sh` per <rule ref="DISCIPLINE §P-diskimage"/>. Point `log2timeline.py` at `/dev/nbd<N>` (from the `manifest.md` disk-mount row, key `nbd=`) — Plaso reads the flat byte stream natively. NEVER point at the original `.E01` / `.vmdk` / etc. file.
+</disk-image-source>
+
 > **Installation:** Plaso 20240308 installed from the GIFT PPA (`ppa:gift/stable`).
 > Packages: `python3-plaso`, `plaso-tools`, `python3-pytsk3`.
 > The standard Ubuntu jammy universe package conflicts with SIFT's libyal libraries —

--- a/.claude/skills/plaso-timeline/reference/example-survey.md
+++ b/.claude/skills/plaso-timeline/reference/example-survey.md
@@ -12,7 +12,7 @@
 - **Evidence ID:** EV01
 - **Evidence sha256:** 4c2e7a8b1d9f005611223344556677889900aabbccddeeff0011223344556677
 - **Domain:** timeline
-- **Surveyor agent version:** dfir-surveyor / discipline_v3_loaded
+- **Surveyor agent version:** dfir-surveyor / discipline_v4_loaded
 - **UTC timestamp:** 2026-04-26 14:55:08 UTC
 
 ## Tools run

--- a/.claude/skills/sigma-hunting/SKILL.md
+++ b/.claude/skills/sigma-hunting/SKILL.md
@@ -5,6 +5,7 @@
   <rule>Tool order is the <code>sigma-hunting</code> entry of DISCIPLINE.md §P-priority. Surveyor runs <code>chainsaw hunt --sigma /opt/sigma-rules/sigma --mapping /opt/sigma-rules/mappings/sigma-event-logs-all.yml --csv -o ./analysis/sigma/&lt;EVID&gt;/ &lt;evtx_dir&gt;</code>.</rule>
   <rule>Hits go to <code>./analysis/sigma/&lt;EVID&gt;/</code> (CSVs). Matched-event byte extracts go to <code>./exports/sigma_hits/&lt;EVID&gt;/&lt;rule_id&gt;/</code>.</rule>
   <rule>Do not author, cache, or vendor rules inside the project workspace. Operator maintains <code>/opt/sigma-rules/</code> via the SIFT install script.</rule>
+  <rule>EVTX corpus on a disk image is read from the partition mount at <code>./working/mounts/&lt;EV&gt;/p&lt;M&gt;/Windows/System32/winevt/Logs/</code> per DISCIPLINE.md §P-diskimage. Do NOT extract via <code>icat</code> first when the mount is available.</rule>
 </protocol>
 
 ## Use this skill when

--- a/.claude/skills/sigma-hunting/reference/example-survey.md
+++ b/.claude/skills/sigma-hunting/reference/example-survey.md
@@ -12,7 +12,7 @@
 - **Evidence ID:** EV01
 - **Evidence sha256:** 81d6f4a9b7c3e205112233445566778899aabbccddeeff00112233445566778b
 - **Domain:** sigma
-- **Surveyor agent version:** dfir-surveyor / discipline_v3_loaded
+- **Surveyor agent version:** dfir-surveyor / discipline_v4_loaded
 - **UTC timestamp:** 2026-04-26 15:14:05 UTC
 
 ## Tools run

--- a/.claude/skills/sleuthkit/SKILL.md
+++ b/.claude/skills/sleuthkit/SKILL.md
@@ -1,8 +1,21 @@
 # Skill: File System & Carving (The Sleuth Kit / EWF Tools)
 
+<disk-image-source>
+Disk images (E01, raw/dd, vmdk, vhd, vhdx, qcow2) are mounted read-only by triage
+via `diskimage-mount.sh` per <rule ref="DISCIPLINE §P-diskimage"/>. TSK tools
+ALWAYS read from the mount surface, NEVER from the original source file:
+
+- **Raw-stream commands** (`mmls`, `fsstat`, `fls`, `img_stat`, `icat`, `ils`, `blkls`, `tsk_recover`) → `/dev/nbd<N>` (read from `manifest.md`'s `disk-mount` row, key `nbd=`)
+- **File-tree access** (`find`, `grep`, parsing individual files copied out via `icat`) → `./working/mounts/<EV>/p<M>/`
+
+The worked examples below show the v3 pattern (`<image>.E01`); replace with
+`/dev/nbd<N>` from the manifest. The byte offsets and command flags remain
+identical — qemu-nbd presents a flat block stream that TSK reads natively.
+</disk-image-source>
+
 ## Use this skill when
-- You have a disk image (`.E01`, `.dd`, `.raw`) and need to walk the filesystem,
-  extract a specific file by inode, or recover deleted entries
+- You have a disk image and need to walk the filesystem, extract a specific
+  file by inode, or recover deleted entries
 - A higher-level skill needs the *raw* artifact (registry hive, EVTX, MFT,
   Prefetch dir, Recycle Bin) extracted from an image before parsing
 - The case asks "was this file ever on disk?" / "when was it deleted?" /

--- a/.claude/skills/sleuthkit/reference/example-survey.md
+++ b/.claude/skills/sleuthkit/reference/example-survey.md
@@ -12,7 +12,7 @@
 - **Evidence ID:** EV01
 - **Evidence sha256:** 5b8c3e2a9f70a1b4c5d6e7f80991a2b3c4d5e6f7081929304a5b6c7d8e9f00ab
 - **Domain:** filesystem
-- **Surveyor agent version:** dfir-surveyor / discipline_v3_loaded
+- **Surveyor agent version:** dfir-surveyor / discipline_v4_loaded
 - **UTC timestamp:** 2026-04-26 14:43:21 UTC
 
 ## Tools run

--- a/.claude/skills/windows-artifacts/SKILL.md
+++ b/.claude/skills/windows-artifacts/SKILL.md
@@ -1,5 +1,9 @@
 # Skill: Windows Artifacts (EZ Tools / Autoruns / Event Logs)
 
+<disk-image-source>
+Artifacts on a Windows disk image are accessed via the read-only mount produced by `diskimage-mount.sh` per <rule ref="DISCIPLINE §P-diskimage"/>. EZ Tools (`EvtxECmd`, `RECmd`, `MFTECmd`, `AmcacheParser`, etc.) read from `./working/mounts/<EV>/p<M>/` directly — e.g. `EvtxECmd --maps ... --csv ... -d ./working/mounts/EV01/p1/Windows/System32/winevt/Logs/`. Do NOT extract artifacts via `icat` first when the partition mount is available; the mount IS the surface.
+</disk-image-source>
+
 ## Use this skill when
 - The case is Windows host-based and you have parsed/parseable artifacts:
   registry hives, EVTX, Prefetch, Amcache, MFT, $J, Recycle Bin, LNK, Jump

--- a/.claude/skills/windows-artifacts/reference/example-survey.md
+++ b/.claude/skills/windows-artifacts/reference/example-survey.md
@@ -12,7 +12,7 @@
 - **Evidence ID:** EV01
 - **Evidence sha256:** 9f4a5b7c2d8e1f30a6b8c0d2e4f6081929384756abcdef0123456789abcdef01
 - **Domain:** windows-artifacts
-- **Surveyor agent version:** dfir-surveyor / discipline_v3_loaded
+- **Surveyor agent version:** dfir-surveyor / discipline_v4_loaded
 - **UTC timestamp:** 2026-04-26 14:08:11 UTC
 
 ## Tools run

--- a/.claude/skills/yara-hunting/SKILL.md
+++ b/.claude/skills/yara-hunting/SKILL.md
@@ -5,6 +5,7 @@
   <rule>Tool order is the <code>yara-hunting</code> entry of DISCIPLINE.md §P-priority. Surveyor runs <code>yara -r /opt/yara-rules/ &lt;target&gt;</code>.</rule>
   <rule>Hits go to <code>./exports/yara_hits/</code>. Summaries to <code>./analysis/yara/</code>.</rule>
   <rule>Do not author, cache, or vendor rules inside the project workspace. Operator maintains <code>/opt/yara-rules/</code> via the SIFT install script.</rule>
+  <rule>Disk-image targets are the read-only mount produced by <code>diskimage-mount.sh</code> per DISCIPLINE.md §P-diskimage. Scan filesystem trees at <code>./working/mounts/&lt;EV&gt;/p&lt;M&gt;/</code> or block streams at <code>/dev/nbd&lt;N&gt;</code>; never the original <code>.E01</code>/<code>.vmdk</code>/etc. file.</rule>
 </protocol>
 
 ## Use this skill when

--- a/.claude/skills/yara-hunting/reference/example-survey.md
+++ b/.claude/skills/yara-hunting/reference/example-survey.md
@@ -12,7 +12,7 @@
 - **Evidence ID:** EV01
 - **Evidence sha256:** 70a8d3b9c5e4f211223344556677889900aabbccddeeff00112233445566778a
 - **Domain:** yara
-- **Surveyor agent version:** dfir-surveyor / discipline_v3_loaded
+- **Surveyor agent version:** dfir-surveyor / discipline_v4_loaded
 - **UTC timestamp:** 2026-04-26 15:02:14 UTC
 
 ## Tools run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ a distinct mutability and integrity contract.
 | # | Layer | Path | Mutability | Integrity ledger |
 |---|-------|------|------------|------------------|
 | 1 | Original evidence | `./evidence/` | Read-only after intake (`chmod a-w`) | `analysis/manifest.md` |
-| 2 | Working copies | `./working/<bundle>/`, `./working/e01/` | Read-only by convention | `analysis/manifest.md` (`bundle-member`, `conversion-e01` rows) |
+| 2 | Working copies | `./working/<bundle>/`, `./working/mounts/<EV>/p<M>/` | Read-only by convention; mounts read-only by kernel | `analysis/manifest.md` (`bundle-member`, `disk-mount` rows) |
 | 3 | Tool reports | `./analysis/<domain>/` | Mutable (recomputable) | None |
 | 4 | Derived artifacts | `./exports/<domain>/...` | Write-once | `analysis/exports-manifest.md` (PostToolUse hook) |
 | 5 | Reports | `./reports/` | Mutable | None |
@@ -98,8 +98,10 @@ Project-wide rules. Canonical definitions in
 - **PCAP order** (`§P-pcap`) is the network entry of `§P-priority`:
   `capinfos` inventory + `zeek` for survey; `suricata`, `tshark`, etc.
   in order for deeper passes.
-- **Non-E01 disk images are converted to E01** in `./working/e01/`
-  before any analysis (`§P-diskimage`).
+- **Disk images are mounted read-only via `qemu-nbd`** (and `ewfmount` for E01)
+  into `./working/mounts/<EV>/p<M>/` after archive extraction. Tools operate
+  off the mount; mounts dismounted at case close. NEVER converted to E01
+  (`§P-diskimage`).
 - **YARA rules** live at `/opt/yara-rules/`; scans read from there; hits
   write to `./exports/yara_hits/` (`§P-yara`).
 - **Sigma rules** live at `/opt/sigma-rules/`; Chainsaw / Hayabusa read

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -123,12 +123,12 @@ finding's confidence by one grade until you can re-derive it.
 
 ### A3. Discipline self-attestation
 
-Every phase agent appends `discipline_v3_loaded` to its first audit
+Every phase agent appends `discipline_v4_loaded` to its first audit
 entry. Confirm every phase that ran left its marker:
 
 ```bash
-grep -c discipline_v3_loaded analysis/forensic_audit.log
-grep    discipline_v3_loaded analysis/forensic_audit.log \
+grep -c discipline_v4_loaded analysis/forensic_audit.log
+grep    discipline_v4_loaded analysis/forensic_audit.log \
     | awk -F'|' '{print $2}' | sort -u
 ```
 
@@ -411,7 +411,7 @@ PROVENANCE & INTEGRITY
 [ ] A1  Evidence sha256 re-hash matches manifest for every EV row
 [ ] A1  Bundle-member spot-check (5 random) matches manifest
 [ ] A2  audit-retrofit.sh: no structural integrity violations
-[ ] A3  Every phase agent left a discipline_v3_loaded marker
+[ ] A3  Every phase agent left a discipline_v4_loaded marker
 [ ] A4  Exports manifest spot-check: 3 random files match recorded sha
 [ ] A5  intake-check.sh: PASS
 
@@ -482,7 +482,7 @@ bash "${CLAUDE_PROJECT_DIR}/.claude/skills/dfir-bootstrap/audit-retrofit.sh" \
     analysis/forensic_audit.log
 
 # A3 — discipline marker count.
-grep -c discipline_v3_loaded analysis/forensic_audit.log
+grep -c discipline_v4_loaded analysis/forensic_audit.log
 
 # B1 — leads invariant.
 bash "${CLAUDE_PROJECT_DIR}/.claude/skills/dfir-bootstrap/leads-check.sh"


### PR DESCRIPTION
## Summary

- Replace the "non-E01 → ewfacquire → E01" pipeline with a uniform read-only mount layer. Naive `ewfacquire` on virtual-disk containers (VMDK/VHD/VHDX/qcow2) reads descriptor + sparse extents verbatim and produces malformed E01s.
- Disk images now mount read-only via `qemu-nbd` (and `ewfmount` for E01) into `./working/mounts/<EV>/p<M>/`. Tools operate off the mount; mount-source byte stream is sha256'd; mounts dismounted at case close OR per-stage in sequential mode.
- Every command against case bytes is recorded as an exact-command audit row (DISCIPLINE §A.1 + new content contract in §P-diskimage).

## What changed

- **DISCIPLINE.md §P-diskimage** — full rewrite: format-adapter table, canonical command sequence, two-row manifest contract (`blob` + `disk-mount`), exact-command audit-row contract.
- **Marker bumped** v3 → v4 across 21 files.
- **Three new bootstrap helpers** (all chmod +x, syntax-clean, idempotent):
  - `diskimage-plan.sh` — format detection, logical-size sizing, mode `bulk`/`sequential`/`blocked` parallel to `extraction-plan.sh`.
  - `diskimage-mount.sh` — uniform pipeline with trap-driven detach on every exit path.
  - `diskimage-unmount.sh` + `diskimage-unmount-all.sh` — adapter-chain reversal; sentinels marked `mounted=false` (chain-of-custody preserved, not deleted).
- **case-init.sh** — pre-creates `./working/mounts/`; sentinel sweep appends `disk-mount` manifest rows from sentinel sha256s.
- **extraction-cleanup.sh** — calls `diskimage-unmount.sh` for any EV under the cleanup target before `rm -rf`; refuses delete on unmount failure.
- **manifest-check.sh** — disk-mount invariants; failures append `L-MOUNT-LEDGER-NN`.
- **preflight.sh** — `bin_check` rows for qemu-nbd / qemu-img / ewfmount / fusermount / ewfacquire; new `SKILL_STATUS:disk-image-mount`.
- **install-tools.sh** — `qemu-utils` + `fuse` added to `BASE_APT_REQUIRED`.
- **dfir-triage.md** — full protocol rewrite (4-substep disk-image gate, explicit reasoning XML).
- **dfir-surveyor.md / dfir-qa.md** — surveyor reads off mount surface; QA case-close calls `diskimage-unmount-all.sh` before sign-off.
- **Domain SKILL.md files** (sleuthkit, plaso-timeline, windows-artifacts, yara-hunting, sigma-hunting) — `<disk-image-source>` block routes tools to `/dev/nbd<N>` or partition mount.
- **ORCHESTRATE.md** — Phase 1 reads BOTH plan files (most-restrictive mode wins); new lead-ID prefixes (`L-MOUNT-DISK`, `L-MOUNT-FAIL`, `L-MOUNT-LEDGER`).
- **refactor-verify.sh** — marker gate v4-only; new gate 8b (residue scan) + 8c (helpers executable).
- **CLAUDE.md** — Layer-2 row + forensic-constraints bullet updated.

`refactor-verify.sh`: PASS.

## Test plan

- [ ] **VMDK mount smoke** — `qemu-img create -f vmdk smoke.vmdk 64M` with an ext4 partition; drop into `cases/smoke-vmdk/evidence/`; run triage; confirm `./working/mounts/EV01/p1/` mounted read-only, manifest has both `blob` and `disk-mount` rows with non-empty sha256, audit log carries the eleven exact-command rows.
- [ ] **E01 mount smoke** — synthesize a small E01 from a raw image; confirm pipeline runs `ewfmount` first, then `qemu-nbd -f raw <ewfmount-dir>/ewf1`; sentinel records both adapter steps.
- [ ] **Raw-via-qemu smoke** — `qemu-img create -f raw smoke.dd 64M` + ext4; confirm conversion uses qemu-nbd `-f raw` (no special-case branch); audit log shows the same sequence as VMDK minus the ewfmount row.
- [ ] **Pressure smoke** — `qemu-img create -f vmdk -o subformat=streamOptimized big.vmdk 1T` on a small partition → planner mode `blocked`, `L-MOUNT-DISK-01` row present.
- [ ] **Failure-path detach** — corrupt a VMDK descriptor; run mount; confirm `qemu-nbd --disconnect` audit row appears even after `qemu-nbd --connect` exits nonzero (trap fired); `L-MOUNT-FAIL-01` appended; no orphan `/dev/nbd<N>` left attached.
- [ ] **Sequential-mode dismount** — synthesize a `tar.gz` with two .vmdk files large enough to trigger sequential mode; confirm stage 1's vmdk mounts during its survey/investigate, `extraction-cleanup.sh` dismounts before `rm -rf`, stage 2 mounts on its turn.
- [ ] **Case-close dismount** — run a clean case to QA phase; confirm `diskimage-unmount-all.sh` runs, every `/dev/nbd<N>` detached, every mount point empty, sentinels carry `unmounted=true`.
- [ ] **Marker bump + residue scan** — `bash .claude/skills/dfir-bootstrap/refactor-verify.sh` PASS; `grep -rn 'discipline_v3_loaded\|working/e01\|conversion-e01' .claude/` empty.
- [ ] **Manifest-check invariant** — corrupt a sentinel sha256; confirm `manifest-check.sh` exits 1 and appends `L-MOUNT-LEDGER-NN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)