### PR TITLE
Audit & remediate project skills: correctness drifts + discoverability frontmatter

### DIFF
--- a/.claude/skills/ORCHESTRATE.md
+++ b/.claude/skills/ORCHESTRATE.md
@@ -77,6 +77,12 @@ write it on first append.
 | Disk-image mount block (phase 1) | `L-MOUNT-DISK-NN` | `L-MOUNT-DISK-01` |
 | Disk-image mount failure (phase 1) | `L-MOUNT-FAIL-NN` | `L-MOUNT-FAIL-01` |
 | Disk-mount manifest invariant (manifest-check) | `L-MOUNT-LEDGER-NN` | `L-MOUNT-LEDGER-01` |
+| Empty / misconfigured evidence (phase 1, case-init) | `L-EVIDENCE-EMPTY-NN` | `L-EVIDENCE-EMPTY-01` |
+| Bundle-expansion failure (phase 1, case-init) | `L-EXTRACT-FAIL-NN` | `L-EXTRACT-FAIL-01` |
+| Extraction poison / unsafe path (phase 1, case-init) | `L-EXTRACT-POISON-NN` | `L-EXTRACT-POISON-01` |
+| Bespoke hash-file refusal (phase 1, manifest-check) | `L-MANIFEST-BESPOKE-NN` | `L-MANIFEST-BESPOKE-01` |
+| Baseline-artifact gap (phase 4) | `L-BASELINE-<DOMAIN>-NN` | `L-BASELINE-memory-01` |
+| Unguided triage (single-context, TRIAGE.md) | `L-TRIAGE-NN` | `L-TRIAGE-01` |
 
 Each prefix is globally unique per source — parallel agents need no shared
 lock. `NN` is zero-padded and counter-scoped to the invocation.
@@ -255,7 +261,7 @@ open-ended enough to touch multiple domains.
 - `pointer` MUST be line-anchored (`<file>#L<n>` or `<file>#L<n>-L<m>`); a bare filename forces an investigator re-scan and wastes context.
 - `status`: `open` → `in-progress` → `confirmed` / `refuted` / `escalated` / `blocked`.
 - Investigator updates `status` before and after its work. Correlator appends `L-CORR-*` rows ONLY; it MUST NOT modify existing rows.
-- All five lead-ID prefixes (surveyor, `-eNN`, `L-CORR-NN`, `L-EXTRACT-RE-NN`, `L-EXTRACT-DISK-NN`) coexist in this single file.
+- Every lead-ID prefix in the registry above (§ Lead ID conventions) can coexist in this single file.
 
 ## Lead terminal-status invariant
 

--- a/.claude/skills/TRIAGE.md
+++ b/.claude/skills/TRIAGE.md
@@ -44,6 +44,14 @@ cd "${CLAUDE_PROJECT_DIR}/cases/<CASE_ID>"
 bash "${CLAUDE_PROJECT_DIR}/.claude/skills/dfir-bootstrap/preflight.sh" \
     | tee ./analysis/preflight.md
 bash "${CLAUDE_PROJECT_DIR}/.claude/skills/dfir-bootstrap/case-init.sh" <CASE_ID>
+
+# Disk-image evidence (E01, raw/dd, vmdk, vhd, vhdx, qcow2): mount read-only
+# BEFORE any filesystem tool runs. Filesystem / Plaso / YARA then read the
+# /dev/nbd<N> device (manifest disk-mount row, key `nbd=`) or the partition
+# tree under ./working/mounts/<EV>/p<M>/ — NEVER the original source file
+# (DISCIPLINE §P-diskimage).
+bash "${CLAUDE_PROJECT_DIR}/.claude/skills/dfir-bootstrap/diskimage-plan.sh"
+bash "${CLAUDE_PROJECT_DIR}/.claude/skills/dfir-bootstrap/diskimage-mount.sh" <evidence-relpath> EV01
 ```
 
 Tier the toolbox per `preflight.md` BEFORE touching evidence: Sleuth Kit +
@@ -83,7 +91,7 @@ Run when triage came up clean and the case still demands an answer. Order;
 STOP the moment any pass surfaces a lead.
 
 1. **Targeted Plaso** — `--parsers winevtx,winreg,prefetch,amcache,recycle_bin_*,mft` over the incident window only. Avoid `win10` full preset on first pass.
-2. **Filesystem timeline** — `fls -r -m / <image>.E01 > bodyfile` → `mactime -y -z UTC` filtered to the window.
+2. **Filesystem timeline** — `fls -r -m / /dev/nbd<N> > bodyfile` (read `nbd=` from `manifest.md`'s disk-mount row; never the original `.E01`/source file, per §P-diskimage) → `mactime -y -z UTC` filtered to the window.
 3. **Security + PowerShell + Sysmon EVTX → CSV** with EvtxECmd `-d` against exported `winevt\Logs\`.
 4. **Memory enumeration** (when image present): `psscan`, `pstree`, `cmdline`, `netscan`, `malfind`, `svcscan` to `./analysis/memory/`.
 5. **Browser history** (user-system): `SQLECmd -d ./exports/browser/` for Chrome/Edge/Firefox profile dirs.

--- a/.claude/skills/dfir-bootstrap/SKILL.md
+++ b/.claude/skills/dfir-bootstrap/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dfir-bootstrap
+description: Case bootstrap, preflight, and fallback-parser plumbing for the SIFT workstation. Use at case start (scaffold, hash, lock evidence read-only), when a fresh shell needs a tool inventory before evidence is touched, when wiring audit.sh / fallback parsers, or when another skill reports missing tools and you need to know what substitutes exist. Triggers — "start a case", "run preflight", "what tools are installed?", "tool is missing — what now?". Skip for deep artifact analysis (use the matching domain skill) or report writing (use `dfir-reporter`).
+---
+
 # Skill: DFIR Bootstrap & Preflight
 
 ## Use this skill when

--- a/.claude/skills/dfir-discipline/SKILL.md
+++ b/.claude/skills/dfir-discipline/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dfir-discipline
+description: The shared rulebook (DISCIPLINE.md) every phase agent must load — audit-log integrity, headline revalidation, hypothesis-first, scope closure, lead-surface, intake/ATT&CK/multi-evidence rules, and per-domain tool priority. Bound by every agent's <mandatory> line; rarely invoked standalone. Triggers — "what's the discipline rule for X?", "§P-priority / §A / §I lookup". Skip for actually running an analysis (use the matching domain skill).
+---
+
 # Skill: DFIR Discipline (shared rules across all phase agents)
 
 <role>

--- a/.claude/skills/exec-briefing/SKILL.md
+++ b/.claude/skills/exec-briefing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: exec-briefing
+description: Decision-focused stakeholder briefing for non-technical senior audiences (legal, risk, executives, incident commanders). Use once per case in Phase 5, alongside final.md, to translate confirmed findings into business language and decisions. Triggers — "write the stakeholder/executive summary", "non-technical briefing", "what do we tell leadership". Skip for the technical analyst report (final.md — use `dfir-reporter`) or per-domain findings (use `dfir-investigator`). Never introduce findings not already in final.md / correlation.md / findings.md.
+---
+
 # Skill: Executive Briefing (non-technical stakeholder report)
 
 Produce a short, decision-focused companion to the technical `final.md`. The

--- a/.claude/skills/memory-analysis/SKILL.md
+++ b/.claude/skills/memory-analysis/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: memory-analysis
+description: Memory forensics with Volatility 3 + Memory Baseliner. Use when a memory image (.raw/.mem/.vmem/.dmp/.lime) is in scope, you need what was actually running vs. what disk shows installed (hidden processes, unlinked drivers, in-memory-only payloads), or the prompt mentions injection, hollowing, fileless malware, lsass access, or in-memory C2. Triggers — "analyze this memory dump", "what was running?", "hidden/injected process", "the binary on disk looks clean". Skip for purely on-disk questions (use `windows-artifacts` / `sleuthkit`).
+---
+
 # Skill: Memory Forensics (Volatility 3 / Memory Baseliner)
 
 ## Use this skill when
@@ -504,7 +509,7 @@ optional: analysis/memory/survey-EV01.md
 ## Notes
 
 - `windows.malware.psxview.PsXView` is the canonical "is this hidden?" cross-source enumerator. `pslist` and `psscan` provide raw column detail (offsets, exit times); use them for column lookup, not for hidden-process detection.
-- `windows.malfind` produces false positives (JIT-compiled code, .NET CLR) — triage hits manually before dumping.
+- `windows.malfind` produces false positives (JIT-compiled code, .NET CLR) — triage hits manually before dumping. *Worked false-positive:* an RWX VAD inside `w3wp.exe` / `powershell.exe` whose process tree is benign and whose `dlllist` shows `clr.dll` / `clrjit.dll` is almost certainly .NET JIT, not an implant — confirm the VAD has **no `MZ` header** (`windows.vadinfo --pid`) before spending a `--dump` + YARA cycle. Record it as a *refuted* lead with that reasoning; do not silently skip it (§G).
 - `windows.netscan` may show connections from before image capture time — correlate with disk timeline.
 - `windows.svcscan` surfaces services configured but not yet loaded, and deleted services still in memory.
 - Vol3 plugins use dotted-namespace names (`windows.malfind`, `windows.registry.printkey`, `windows.malware.psxview.PsXView`, plus the cross-platform `timeliner` with no `windows.` prefix). Copy the exact name from `vol.py -h`.

--- a/.claude/skills/memory-analysis/reference/example-survey.md
+++ b/.claude/skills/memory-analysis/reference/example-survey.md
@@ -23,7 +23,7 @@
 - `windows.cmdline` -> `python3 /opt/volatility3/vol.py -f ./evidence/JANE-WIN10-DESKTOP.mem windows.cmdline` -> exit 0 -> `./analysis/memory/cmdline.txt`
 - `windows.netscan` -> `python3 /opt/volatility3/vol.py -f ./evidence/JANE-WIN10-DESKTOP.mem windows.netscan` -> exit 0 -> `./analysis/memory/netscan.txt`
 - `windows.malfind` -> `python3 /opt/volatility3/vol.py -f ./evidence/JANE-WIN10-DESKTOP.mem windows.malfind` -> exit 0 -> `./analysis/memory/malfind.txt`
-- `Memory Baseliner (proc)` -> `python3 /opt/volatility3/baseline.py -proc -f ./evidence/JANE-WIN10-DESKTOP.mem --loadbaseline ./baselines/win10_19045_clean.json --jsonbaseline -o ./analysis/memory/baseliner-proc.json` -> exit 0 -> `./analysis/memory/baseliner-proc.json`
+- `Memory Baseliner (proc)` -> `python3 /opt/volatility3/baseline.py -proc -i ./evidence/JANE-WIN10-DESKTOP.mem --loadbaseline --jsonbaseline ./baselines/win10_19045_clean.json -o ./analysis/memory/baseliner-proc.tsv` -> exit 0 -> `./analysis/memory/baseliner-proc.tsv`
 
 ## Findings of interest
 
@@ -31,7 +31,7 @@
 - `psxview` shows PID 4488 (`updater.exe`) listed by `psscan` and `thrdproc` but absent from `pslist` and `csrss_handles` — classic hide-from-pslist pattern; parent PID 624 is `lsass.exe` which is highly anomalous (`./analysis/memory/psxview.csv#L42`). Lead: `L-EV03-memory-02`
 - `windows.malfind` reports one RWX VAD inside PID 4488 with valid `MZ` header at `0x000001f3a0000000`, entropy 7.91, no on-disk file backing — strong injected-PE indicator (`./analysis/memory/malfind.txt#L88-L120`). Lead: `L-EV03-memory-03`
 - `windows.netscan` shows PID 4488 has an ESTABLISHED TCP connection to `185.220.101.42:443`, owner `NT AUTHORITY\SYSTEM` — same IP as the network-forensics beacon target; pivots cleanly with the network domain (`./analysis/memory/netscan.txt#L73`). Lead: `L-EV03-memory-04`
-- Memory Baseliner diff vs `win10_19045_clean.json` flags 3 unique deltas: (a) `updater.exe` PID 4488 (no baseline match), (b) `svchost.exe` PID 1972 with non-default service-host group `netsvcs+UnistackSvcGroup` (rare combination), (c) `winlogon.exe` PID 624 has a non-baseline DLL `crypto32.dll` loaded (`./analysis/memory/baseliner-proc.json#L201-L260`). Lead: `L-EV03-memory-05`
+- Memory Baseliner diff vs `win10_19045_clean.json` flags 3 unique deltas: (a) `updater.exe` PID 4488 (no baseline match), (b) `svchost.exe` PID 1972 with non-default service-host group `netsvcs+UnistackSvcGroup` (rare combination), (c) `winlogon.exe` PID 624 has a non-baseline DLL `crypto32.dll` loaded (`./analysis/memory/baseliner-proc.tsv#L201-L260`). Lead: `L-EV03-memory-05`
 
 ## Lead summary table
 

--- a/.claude/skills/network-forensics/SKILL.md
+++ b/.claude/skills/network-forensics/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: network-forensics
+description: PCAP / Zeek / Suricata / NetFlow analysis. Use when a packet capture, Zeek logs, Suricata eve.json, or flow records are in scope, or a host-side indicator (IP, domain, JA3, TLS SNI, UA, URI, cert hash) needs confirming on the wire. Triggers — "what was on the wire?", "did this host beacon?", "was data exfiltrated?", "analyze this pcap". Skip for purely host-resident artifacts (use `windows-artifacts`) or memory-resident connections only (use `memory-analysis`).
+---
+
 # Skill: Network Forensics (PCAP / Zeek / Suricata / Flow)
 
 <protocol>
@@ -643,7 +648,14 @@ optional: analysis/network/zeek/files.log
 - **Beaconing detection has high false-positive rate.** Browser keepalives,
   NTP, automatic update checks, and antivirus phone-home all look like
   beaconing. Always confirm with JA3/SNI + process attribution before
-  reporting.
+  reporting. *Worked false-positive:* a low-jitter, high-count candidate to
+  `time.windows.com` / `*.pool.ntp.org` over UDP/123 with small symmetric
+  payloads is NTP, not C2 — `conn.log` `service` reads `ntp`, the cadence
+  matches the host's `w32time` poll interval, and there is no preceding
+  DNS→IP→TLS pattern. Mark it *refuted* with that evidence rather than
+  escalating. Genuine C2 shows a TLS/HTTP service, a JA3 matching a known
+  family (or no SNI at all), and a process owner that is not a system
+  time/update service.
 - **Encrypted traffic limits conclusions.** SNI + JA3 + cert chain + flow size
   + cadence are the only L7-adjacent signals. State this gap explicitly in
   `findings.md` and `00_intake.md` rather than overclaiming.

--- a/.claude/skills/plaso-timeline/SKILL.md
+++ b/.claude/skills/plaso-timeline/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: plaso-timeline
+description: Cross-artifact super-timelines with Plaso / log2timeline. Use when you need one chronological stream across filesystem + EVTX + registry + browser + prefetch, want everything inside an incident window regardless of source, or are merging heterogeneous evidence (disk + memory bodyfile + log dir) into one sortable timeline. Triggers — "build a super-timeline", "what happened in this window", "merge these into one timeline". Skip for a targeted single-artifact question (use `windows-artifacts`) or raw filesystem walking/carving (use `sleuthkit`).
+---
+
 # Skill: Timeline Generation (Plaso / log2timeline)
 
 <disk-image-source>

--- a/.claude/skills/sigma-hunting/SKILL.md
+++ b/.claude/skills/sigma-hunting/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: sigma-hunting
+description: Signature-based EVTX triage with Chainsaw + Hayabusa over Sigma rules. Use when you have a corpus of Windows .evtx logs and want portable rule-based detection instead of grep-by-EventID, or need to cross-correlate another skill's finding against event-log signal. Triggers — "run Sigma over these logs", "Chainsaw/Hayabusa hunt", "signature triage of EVTX". Skip for byte/IOC sweeps over files or memory (use `yara-hunting`) or hand-targeted single-EventID lookups (use `windows-artifacts`).
+---
+
 # Skill: Sigma / EVTX Hunting (Chainsaw + Hayabusa)
 
 <protocol>

--- a/.claude/skills/sleuthkit/SKILL.md
+++ b/.claude/skills/sleuthkit/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: sleuthkit
+description: File-system and carving analysis on a disk image with The Sleuth Kit + EWF tools. Use when walking a filesystem, extracting a file by inode, recovering deleted entries, inspecting unallocated/slack, carving (PhotoRec/bulk_extractor), or when another skill needs a raw artifact (hive, EVTX, MFT, Prefetch, Recycle Bin) extracted from an image first. Triggers — "was this file on disk?", "when was it deleted?", "what's in unallocated?", "recover this inode/file", "carve files". Skip for parsing already-extracted Windows artifacts (use `windows-artifacts`) or memory images (use `memory-analysis`).
+---
+
 # Skill: File System & Carving (The Sleuth Kit / EWF Tools)
 
 <disk-image-source>

--- a/.claude/skills/windows-artifacts/SKILL.md
+++ b/.claude/skills/windows-artifacts/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: windows-artifacts
+description: Windows host artifact analysis with EZ Tools / Autoruns / event logs (EVTX, registry, Prefetch, Amcache, Shimcache, LNK, SRUM, USB, shellbags, browser). Use when the case is Windows host-based and you can name the question — execution, logon/authentication, persistence, USB/removable media, deletion, or anti-forensics. Triggers — "did <binary> run?", "who logged on?", "how does it persist?", "what USB was attached?", "were logs cleared?". Skip for extracting the artifact from an image first (use `sleuthkit`) or memory images (use `memory-analysis`).
+---
+
 # Skill: Windows Artifacts (EZ Tools / Autoruns / Event Logs)
 
 <disk-image-source>

--- a/.claude/skills/yara-hunting/SKILL.md
+++ b/.claude/skills/yara-hunting/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: yara-hunting
+description: IOC byte-sweeps and malware-family attribution with YARA / Velociraptor. Use when you have at least one concrete indicator (hash, mutex, named pipe, unique string, code pattern) to sweep the rest of the evidence for siblings, need to attribute a recovered binary to a family, or want to lift another skill's finding into a reusable rule. Triggers — "YARA sweep", "scan for this IOC", "identify this malware family", "hunt siblings of this sample". Skip for EVTX signature matching (use `sigma-hunting`); not a discovery tool — do not reach here with no indicator yet.
+---
+
 # Skill: Threat Hunting & IOC Sweeps (YARA / Velociraptor)
 
 <protocol>


### PR DESCRIPTION
Closes #17

## What this does

Audit-driven remediation of the project skills. 13 files changed (+77 / −6), all under `.claude/skills/`.

### Tier 1 — correctness drifts
- **`TRIAGE.md`** — the unguided path taught `fls … <image>.E01` (a direct source read) and never mounted; now mounts via `diskimage-mount.sh` and reads `/dev/nbd<N>`, matching `sleuthkit/SKILL.md` + DISCIPLINE §P-diskimage.
- **`memory-analysis/reference/example-survey.md`** — malformed baseliner command (`-f`→`-i`, baseline path mis-attached to boolean `--loadbaseline`, `.json`→`.tsv`) that disagreed with the skill's own canonical line. Surveyors copy this file, so the bug propagated. Still lints clean (exit 0).
- **`ORCHESTRATE.md`** — completed the lead-ID registry (`L-BASELINE`, `L-TRIAGE`, bootstrap edge prefixes) and removed the stale "five prefixes" count.

### Tier 2 — discoverability
- Added `name` + `description` frontmatter to all 10 domain `SKILL.md` files, lifting each skill's "Use this skill when" content into a router-visible `description` with explicit `Triggers —` and `Skip for … (use …)`. Previously the router saw only the H1.

### Tier 3 — polish
- Worked false-positive examples for `memory-analysis` (malfind/.NET JIT) and `network-forensics` (NTP vs C2).

## Verification
- TRIAGE has no direct `.E01` filesystem-read commands remaining.
- `lint-survey.sh` still exits 0 on the edited example-survey.
- All 10 frontmatter blocks parse (harness re-registered the skills with the new descriptions).

## Deferred (documented in #17)
Body-splitting the 4 long skill bodies (advisory-only, high churn) and two cosmetic minor fixes — flagged, not imposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)